### PR TITLE
feat(agent): ReAct architecture with planning, step tracing, and ToolRegistry

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,95 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Build & Run
+
+```bash
+# Start infrastructure (PostgreSQL + Redis)
+docker-compose up -d postgres redis
+
+# Run application
+export OPENAI_API_KEY=sk-your-key-here
+./mvnw spring-boot:run
+
+# Build JAR
+./mvnw clean package -DskipTests
+
+# Run all tests
+./mvnw test
+
+# Run a single test class
+./mvnw test -Dtest=AgentOrchestratorTest
+
+# Run a single test method
+./mvnw test -Dtest=AgentOrchestratorTest#shouldCollectSteps
+```
+
+## Architecture
+
+**Request flow:**
+```
+ChatController
+  └── ChatService
+        ├── RagService.buildContext()     ← pre-fetch RAG context (soft-coupled, to be replaced by RAG-as-Tool)
+        └── AgentOrchestrator.chat()
+              ├── StepCollector.init()
+              ├── TaskPlanner.plan()        ← separate LLM call, temperature=0.3, generates JSON plan
+              ├── chatClient.prompt()
+              │     .toolNames(...)         ← Spring AI runs the ReAct loop internally (no explicit while)
+              │     .call()
+              │         └── ToolExecutionAspect (@Around AOP)  ← intercepts every tool apply()
+              │               └── StepCollector.record()
+              ├── StepCollector.collect()
+              └── StepCollector.clear()     ← always in finally, prevents ThreadLocal leak
+```
+
+**Key design decisions:**
+- Spring AI's `.toolNames().call()` **is** the ReAct loop — it sends tool schemas to the LLM, executes tool calls, feeds results back, and repeats until the LLM stops calling tools. There is no explicit `while` loop in application code.
+- `StepCollector` uses `ThreadLocal` to bridge `ToolExecutionAspect` → `AgentOrchestrator` without coupling them.
+- `TaskPlanner` makes an independent LLM call before the main chat to generate a step plan injected into the system prompt. Failure degrades gracefully (returns empty list).
+- Tools (`WeatherTool`, `CalculatorTool`) implement `Function<Request, Response>` and are annotated `@Component` + `@Description`. The AOP pointcut `execution(* com.dawn.ai.agent.tools.*.apply(..))` auto-traces all tools in this package.
+- `maxSteps` in `application.yml` is currently a soft hint in the system prompt only — not enforced in code.
+
+## Infrastructure
+
+| Service | Port | Purpose |
+|---|---|---|
+| Spring Boot app | 8080 | REST API |
+| PostgreSQL | 5432 | JPA + pgvector (RAG embeddings) |
+| Redis | 6379 | Conversation memory (`MemoryService`) |
+| Prometheus | 9090 | Metrics scraping |
+| Grafana | 3000 | Dashboards (admin/admin123) |
+
+`application.yml` reads `OPENAI_API_KEY` from environment. Without it, `AiAvailabilityChecker` rejects all requests with a clear error before they reach the LLM.
+
+## Adding a New Tool
+
+1. Create `src/main/java/com/dawn/ai/agent/tools/MyTool.java` implementing `Function<MyTool.Request, MyTool.Response>`
+2. Annotate with `@Component` and `@Description("...")`
+3. Add the bean name to `.toolNames(...)` in `AgentOrchestrator` and to `getToolDescriptions()` — until Issue #1 (ToolRegistry) is implemented, this is manual.
+
+`ToolExecutionAspect` will automatically trace the new tool with zero changes.
+
+## Key Config Properties (`application.yml`)
+
+```yaml
+app.ai.react.max-steps: 10        # LLM hint only, not enforced in code
+app.ai.react.show-steps: false    # include AgentStep list in ChatResponse
+app.ai.react.plan-enabled: true   # toggle TaskPlanner pre-execution planning
+app.ai.system-prompt: |           # base system prompt for all sessions
+```
+
+## Planned Work
+
+See `docs/action-plan-2026-03-20.md` for the full next-action roadmap.
+GitHub Issues: https://github.com/Supremes/dawn-ai/issues
+
+Active work items (P0 first):
+- **#1** Dynamic ToolRegistry — remove hardcoded toolNames
+- **#2** Streaming SSE endpoint
+- **#3** RAG as a Tool (Agentic RAG Level 1)
+- **#4** maxSteps hard limit via ToolExecutionAspect
+- **#5** Telemetry: token usage, per-tool histogram, error classification
+- **#7** Structured Output via `BeanOutputConverter` (replace soft prompt constraints + `extractJson()`)
+- **#6** Unit + integration test coverage ≥ 70%

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,8 @@ services:
       - "5005:5005"
     environment:
       - OPENAI_API_KEY=${OPENAI_API_KEY}
+      - BASE_URL=${BASE_URL}
+      - MODEL=${MODEL}
       - SPRING_DATASOURCE_URL=jdbc:postgresql://postgres:5432/dawn_ai
       - SPRING_DATASOURCE_USERNAME=dawn
       - SPRING_DATASOURCE_PASSWORD=dawn123

--- a/docs/action-plan-2026-03-20.md
+++ b/docs/action-plan-2026-03-20.md
@@ -1,0 +1,332 @@
+# Dawn AI — Next Action Plan
+
+> 创建日期：2026-03-20
+> 更新日期：2026-03-20（Mentor Agent 深度评审后修订）
+> 基准版本：`feature/react-redesign`（commit `8012f58`）
+> GitHub Issues：https://github.com/Supremes/dawn-ai/issues
+
+---
+
+## 现状诊断
+
+### 原有结构性缺陷
+
+| # | 问题 | 代码位置 | 严重性 |
+|---|---|---|---|
+| 1 | 工具列表硬编码在 Orchestrator | `AgentOrchestrator:83` | 高 |
+| 2 | 无 Streaming，全部阻塞式响应 | `ChatService:50` | 高 |
+| 3 | RAG 与 Agent 完全割裂，无法按需检索 | `ChatService:43-49` | 高 |
+| 4 | `maxSteps` 只是提示词约束，无代码硬限制 | `AgentOrchestrator:73` | 中 |
+| 5 | Telemetry 覆盖极薄，Token 用量/工具级指标缺失 | 多处 | 中 |
+| 6 | 零测试覆盖 | — | 中 |
+| 7 | 结构化输出依赖提示词软约束 + `extractJson()` 防御性解析 | `TaskPlanner:96-103` | 中 |
+
+### Mentor 评审新发现的问题
+
+| # | 问题 | 代码位置 | 严重性 |
+|---|---|---|---|
+| B1 | RAG context 拼入 userMessage 后存入 Redis，**污染后续对话历史** | `ChatService:43-48` | 高 |
+| B2 | `markPlanStepsCompleted` 用 Set 比对，无法区分顺序和多次调用 | `AgentOrchestrator:144-152` | 中 |
+| B3 | `simpleChat` 绕过所有 Agent 基础设施（无 session/工具/metrics） | `ChatService:64-71` | 中 |
+| B4 | `MemoryService` Redis 不可用时无 Failsafe，可能导致 `doChat()` 整体失败 | `AgentOrchestrator:109-122` | 中 |
+
+> Bug B1 不需要新建 Issue，**在 Action 3（RAG as a Tool）里一并修复**：删除 ChatService 预处理逻辑后，该 Bug 自然消除。
+
+---
+
+## Action 列表
+
+### Action 7 — Structured Output 硬约束（P0，最先做）
+
+**GitHub Issue**：[#7](https://github.com/Supremes/dawn-ai/issues/7)
+
+**问题**：`TaskPlanner` 依赖提示词软约束，并用 `extractJson()` 做防御性解析兜底，是持续在生产中制造风险的定时炸弹。
+
+**软约束 vs 硬约束对比**：
+
+```
+软约束（当前）:
+  Prompt: "只返回 JSON 数组，不要其他文字"
+  → LLM 可能返回 markdown 代码块 + 多余文字
+  → extractJson() 勉强解析
+  → 字段类型错误在运行时 NPE，fallback 掩盖真实解析失败
+
+硬约束（目标）:
+  API 层注入 JSON Schema
+  → OpenAI 在采样阶段约束 token 合法性
+  → 返回结果 100% 符合 Schema，直接反序列化
+```
+
+**方案（Spring AI BeanOutputConverter）**：
+
+```java
+BeanOutputConverter<List<PlanStep>> converter =
+    new BeanOutputConverter<>(new ParameterizedTypeReference<List<PlanStep>>() {});
+
+String response = chatClient.prompt()
+    .user(prompt + converter.getFormat())  // 自动注入 JSON Schema
+    .call()
+    .content();
+
+List<PlanStep> plan = converter.convert(response);
+```
+
+**改造后可删除**：`TaskPlanner.extractJson()` 方法、prompt 中的手写格式说明。
+
+---
+
+### Action 1 — 工具动态注册（P0）
+
+**GitHub Issue**：[#1](https://github.com/Supremes/dawn-ai/issues/1)
+
+**问题**：`AgentOrchestrator` 和 `TaskPlanner` 中工具名称与描述全部硬编码，新增工具必须修改 Orchestrator。当前存在**双重维护税**：`toolNames()` 列表与 `getToolDescriptions()` Map 完全割裂，Bean 是否真实存在在运行时才能发现。
+
+**方案**：
+- 新增 `ToolRegistry`，启动时自动扫描符合条件的 Tool Bean，收集 name + description
+- `AgentOrchestrator` 改为 `toolNames(toolRegistry.getNames())`
+- `TaskPlanner` 改为 `toolRegistry.getDescriptions()`
+
+**效果**：新增 Tool Bean 后，Orchestrator 和 Planner 自动感知，零改动。
+
+---
+
+### Action 2 — Streaming SSE（P0）
+
+**GitHub Issue**：[#2](https://github.com/Supremes/dawn-ai/issues/2)
+
+**问题**：当前全部阻塞等待 LLM 生成完毕，用户体验差。
+
+**注意**：Streaming 模式下 `Flux` 里的异常处理方式与同步不同，需在 Action 4（maxSteps 硬限制）的 `MaxStepsExceededException` 处理中同步考虑。
+
+**方案**：
+- 新增 `GET /api/v1/chat/stream` endpoint，返回 `Flux<ServerSentEvent<String>>`
+- `AgentOrchestrator` 新增 `streamChat()` 使用 `.stream().content()`
+- 原 `POST /api/v1/chat` 保持不变
+
+---
+
+### Action 3 — RAG as a Tool / Agentic RAG Level 1（P1）
+
+**GitHub Issue**：[#3](https://github.com/Supremes/dawn-ai/issues/3)
+
+**问题**：RAG 在 `ChatService` 层作为预处理强制执行，且存在**历史消息污染 Bug**：RAG context 被拼入 `userMessage` 后存入 Redis，下一轮对话 LLM 会看到被 RAG context 填充的"历史用户消息"，污染对话上下文。
+
+**方案**：
+- 新增 `KnowledgeSearchTool`，封装 `RagService.buildContext()`，注册为 Spring Bean
+- **完全删除** `ChatService` 中的 `ragEnabled` 预处理逻辑（同时消除 Bug B1）
+- 删除 `ChatRequest.ragEnabled` 字段
+- Agent 在 ReAct 循环中自主决定何时调用知识库工具
+
+**与 Agentic RAG 的关系**：
+
+```
+Agentic RAG 完整形态（层次递进）：
+  Level 1: RAG as a Tool       ← 本 Action，Agent 决定"要不要"检索
+  Level 2: Query Rewriting       Agent 先改写查询再检索
+  Level 3: Iterative Retrieval   多轮检索直到信息充分
+  Level 4: Self-RAG              带自我反思的检索决策
+```
+
+**ReAct 循环示意（改造后）**：
+```
+User: "Dawn AI 月费是多少？算年费"
+LLM Reason: 需查知识库
+LLM Action: knowledgeSearchTool("Dawn AI 月费")
+Observe:    [月费 ¥99...]
+LLM Reason: 已知月费，执行计算
+LLM Action: calculatorTool("99 * 12")
+Observe:    1188
+LLM: 年费为 ¥1188
+```
+
+---
+
+### Action 4 — maxSteps 硬限制（P1）
+
+**GitHub Issue**：[#4](https://github.com/Supremes/dawn-ai/issues/4)
+
+**问题**：`maxSteps` 只通过提示词告知 LLM，若 LLM 忽视该指令，可能无限循环调用工具，成本失控。
+
+**实现位置修正**（Mentor 评审意见）：不在 `ToolExecutionAspect` 里注入 `maxSteps`，而是通过 `StepCollector.init(int maxSteps)` 让 Collector 自身负责边界检查——Aspect 保持纯粹的观测职责，边界控制收拢到 Collector。
+
+```java
+// AgentOrchestrator:
+StepCollector.init(maxSteps);
+
+// StepCollector:
+public static void init(int maxSteps) {
+    STEPS.get().clear();
+    COUNTER.get().set(0);
+    MAX_STEPS.set(maxSteps);
+}
+
+// 在 nextStepNumber() 或 record() 中检查：
+if (COUNTER.get().get() >= MAX_STEPS.get()) {
+    throw new MaxStepsExceededException(MAX_STEPS.get());
+}
+```
+
+---
+
+### Action 5 — Telemetry 补全（P1）
+
+**GitHub Issue**：[#5](https://github.com/Supremes/dawn-ai/issues/5)
+
+**现状**：
+
+```java
+// 已有（覆盖极薄）
+Timer("ai.agent.chat.duration")        // AgentOrchestrator — 仅整体耗时
+Counter("ai.rag.ingestion.total")      // RagService — 仅次数
+Counter("ai.rag.retrieval.total")      // RagService — 仅次数
+// ToolExecutionAspect 的工具耗时只写入 StepCollector（内存），重启即丢
+```
+
+**缺失指标及补全方案**：
+
+| 指标 | 实现位置 | 说明 |
+|---|---|---|
+| `ai.tool.duration{tool=...}` | `ToolExecutionAspect` | 工具级 Histogram，按工具名 tag，持久化到 Prometheus |
+| `ai.token.input` / `ai.token.output` | `AgentOrchestrator` | 从 `ChatResponse.getMetadata().getUsage()` 提取 |
+| `ai.planner.result{status=success/fallback}` | `TaskPlanner` | Planner 成功率 |
+| `ai.rag.retrieval.result{result=hit/miss}` | `RagService` | RAG 命中率 |
+| `ai.error.total{type=...}` | `ApiExceptionHandler` | 错误分类统计 |
+| `ai.plan.alignment{result=matched/unmatched}` | `AgentOrchestrator` | Plan-Execution 对齐率（配合 B2 修复） |
+
+> 依赖 Action 1（需要 tool tag 语义稳定）和 Action 3（需要 RAG hit/miss 语义）完成后再做。
+
+---
+
+### Action 6 — 补全单元测试与集成测试（P2）
+
+**GitHub Issue**：[#6](https://github.com/Supremes/dawn-ai/issues/6)
+
+**测试策略**：
+
+| 测试类 | 重点 |
+|---|---|
+| `AgentOrchestratorTest` | Mock ChatClient，验证 plan 注入、steps 收集、ThreadLocal 清理 |
+| `TaskPlannerTest` | BeanOutputConverter 正确解析、LLM 格式错误时明确报错（非静默 fallback） |
+| `RagServiceTest` | Mock VectorStore，验证 retrieve 和 buildContext |
+| `StepCollectorTest` | ThreadLocal 多线程隔离、maxSteps 触发异常 |
+| `ToolExecutionAspectTest` | AOP 拦截后 AgentStep 正确记录，工具异常时步骤编号一致性 |
+| `ChatControllerTest` | MockMvc API 契约验证 |
+
+**目标**：核心业务类行覆盖率 ≥ 70%，`mvn test` 全部通过。
+
+---
+
+### Bug Fix 1 — markPlanStepsCompleted 语义修正
+
+**GitHub Issue**：[#8](https://github.com/Supremes/dawn-ai/issues/8)
+
+**问题**：当前用 `Set<String>` 判断工具是否被调用，无法区分调用顺序和多次调用，Plan-Execution 对齐只有形式没有实质。
+
+**方案**：改为按顺序逐步匹配，记录每个 PlanStep 对应的实际 AgentStep 引用，供 Telemetry 使用。
+
+---
+
+### Bug Fix 2 — simpleChat 使用范围明确化
+
+**GitHub Issue**：[#9](https://github.com/Supremes/dawn-ai/issues/9)
+
+**问题**：`ChatService.simpleChat()` 完全绕过 `AgentOrchestrator`、`ToolExecutionAspect`、`MemoryService`，是一个无 session/工具/metrics 的裸 LLM 调用，使用场景不明确。
+
+---
+
+### Bug Fix 3 — MemoryService Redis Failsafe
+
+**GitHub Issue**：[#10](https://github.com/Supremes/dawn-ai/issues/10)
+
+**问题**：Redis 不可用时 `buildHistory()` 行为未验证，可能导致整个 `doChat()` 失败，需要确认并加入 Failsafe（返回空历史而非抛异常）。
+
+---
+
+## 执行顺序（修订版）
+
+```
+Day 1-2:  Action 7  — BeanOutputConverter（独立，消除 extractJson 定时炸弹）
+
+Day 3-5:  Action 1  — ToolRegistry
+          Bug Fix 1 — markPlanStepsCompleted 语义修正（顺带做，代码量小）
+
+Week 2:   Action 3  — KnowledgeSearchTool（依赖 Action 1；同时消除 Bug B1 RAG 历史污染）
+          Action 4  — maxSteps 硬限制（StepCollector.init(maxSteps) 方案）
+
+Week 3:   Action 2  — Streaming SSE（核心逻辑稳定后更安全）
+          Action 5  — Telemetry 补全（依赖 Action 1 + Action 3 tag 语义稳定）
+          Bug Fix 2 — simpleChat 使用范围明确化
+          Bug Fix 3 — MemoryService Redis Failsafe
+
+Week 4:   Action 6  — 补测试（覆盖所有新增逻辑）
+```
+
+---
+
+## 依赖关系图
+
+```
+Action 7（BeanOutputConverter）  ← 独立，最先做
+Action 1（ToolRegistry）         ← 其他 Action 的基础
+    ├── Action 3（RAG as Tool）  ← 强依赖 Action 1
+    ├── Action 4（maxSteps）     ← 弱依赖 Action 1（共用 StepCollector）
+    └── Action 5（Telemetry）    ← 依赖 Action 1 + Action 3 的 tag 语义
+
+Action 2（Streaming SSE）        ← 独立，但放在核心逻辑稳定后更安全
+    └── 影响 Action 4 的异常处理设计（Flux 里 catch 方式不同）
+
+Action 6（测试）                 ← 最后做，覆盖所有新增逻辑
+```
+
+---
+
+## "高级 Java 开发"到"AI Agent 架构师"缺失的核心能力
+
+当前项目已实现 ReAct 骨架，但距离 Agent 架构师视角还差以下四个维度：
+
+### 1. 语义失败治理（Reliability Engineering）
+
+传统后端失败是确定性的（NPE、超时），Agent 系统有独特的**语义失败**：LLM 返回 200 OK、JSON 解析成功、工具也执行了，但最终答案是错的。当前项目完全没有检测机制。需要：
+- Plan Verification（计划执行结果与预期是否一致）
+- Output Validation（工具返回值合理性校验）
+- Conversation Drift Detection（多轮后 Agent 是否跑偏）
+
+### 2. 成本治理（Cost Governance）
+
+每次对话调用两次 LLM（Planner + ReAct loop），ReAct 内部每轮工具调用都把完整历史重新发给 LLM，Token 用量随对话轮数**二次方增长**。Telemetry 是基础，上层还需要：
+- Token Budget（每次请求预算上限）
+- Context Window Management（历史消息滑动窗口裁剪）
+- Model Routing（简单任务用低成本模型）
+
+### 3. 多 Agent 协作（Multi-Agent Orchestration）
+
+单 Orchestrator 在工具超过 10 个后会遇到 LLM 注意力稀释问题。需要把专业工具分组，由专门的 Sub-Agent 负责，主 Agent 做任务路由——类比从单体服务到微服务的架构演进。
+
+### 4. Durable Execution（状态持久化与恢复）
+
+`StepCollector` 是纯内存 ThreadLocal，进程重启后进行中的任务完全丢失，无法异步化长耗时任务。需要 Agent 中间状态持久化（Redis-based checkpoint 或 Temporal Workflow）。
+
+---
+
+## Spring AI ReAct 机制说明
+
+Spring AI 的 `.toolNames().call()` 内部已经是一个隐式的 ReAct 循环：
+
+```
+chatClient.prompt().toolNames(...).call()  ← 这一行内部是循环
+
+内部逻辑（伪代码）:
+while (true) {
+    response = LLM(messages + tool_schemas)
+    if (response 是纯文本) return response
+    if (response 是 tool_call) {
+        result = 执行工具(tool_call)
+        messages.append(tool_call + result)  // Observe
+        // 继续循环，LLM 看到 Observation 后再 Reason
+    }
+}
+```
+
+本项目在此基础上叠加了：
+- **循环前**：`TaskPlanner` 独立 LLM 调用，生成计划引导推理方向
+- **循环中**：`ToolExecutionAspect` AOP 透明拦截，记录每次 Action + Observe

--- a/docs/refactor-plan-2026-03-20.md
+++ b/docs/refactor-plan-2026-03-20.md
@@ -1,0 +1,250 @@
+# Dawn AI 整改计划
+
+> 基于 `feature/react-redesign` 分支 (commit `8012f58`) 全量代码审计后制定
+
+---
+
+## 现状诊断（比现有 action-plan 更深一层）
+
+现有 `docs/action-plan-2026-03-20.md` 列出了 7 个 Action，但存在三个结构性问题：
+
+1. **测试放最后（Week 4）是经典瀑布反模式** — 每个 Phase 新增的逻辑如果不立即配套测试，后期补测时上下文已丢失，测试质量必然下降。
+2. **Telemetry 作为独立 Phase 也是错的** — 可观测性是横切关注点，应随代码一起长出来，而不是事后插桩。每次改动时"顺手"加指标，边际成本最低。
+3. **缺少 Phase 0（地基）** — 分支未合并、硬编码值散落、零 CI、测试基础设施缺失。在这个地基上直接盖功能，返工概率极高。
+
+### 代码级问题清单（超出现有 action-plan 的发现）
+
+| # | 问题 | 位置 | 说明 |
+|---|---|---|---|
+| A | `model = "gpt-4o"` 硬编码 | `ChatService` | 应从 Spring AI 配置读取，而非写死 |
+| B | Memory 参数全部硬编码 | `MemoryService` | `MAX_HISTORY=20`, `SESSION_TTL=2h` 应提取为配置 |
+| C | RAG topK=5 硬编码 | `RagService.buildContext()` | 应可配置或由调用方传入 |
+| D | 无 CI Pipeline | 项目根目录 | 无 GitHub Actions，代码质量无自动化守护 |
+| E | 无错误恢复策略 | `AgentOrchestrator` | LLM 调用无 retry/timeout/fallback，一次超时整个请求挂掉 |
+| F | CLAUDE.md / action-plan 未提交 | 工作目录 | untracked 文件，团队成员无法看到 |
+
+---
+
+## 整改计划
+
+### 设计原则
+
+- **每个 Phase 自带测试** — 不单独设"补测试"阶段，测试随功能一起交付
+- **每个 Phase 自带指标** — Telemetry 不再是独立 Action，而是每次改动的 checklist 项
+- **Phase 间松耦合** — 每个 Phase 合并后系统可独立运行，不存在"做了一半不能用"的中间态
+- **先加护栏，再加能力** — 安全限制 (#4 maxSteps) 在新功能 (#3 Agentic RAG) 之前
+
+---
+
+### Phase 0 — 地基夯实
+
+**目标**：清理技术债，建立自动化基础，让后续 Phase 站在可靠的地面上。
+
+#### 0.1 分支整理与提交
+
+- 将 `feature/react-redesign` 合并到 `master`（该分支的 ReAct 重构已是项目主要代码）
+- 提交 `CLAUDE.md` 和 `docs/action-plan-2026-03-20.md`
+- 后续每个 Phase 从 master 拉新分支，完成后 PR 合回
+
+#### 0.2 硬编码提取为配置
+
+- `ChatService` 中 `model = "gpt-4o"` → 从 `spring.ai.openai.chat.options.model` 读取
+- `MemoryService` 中 `MAX_HISTORY` / `SESSION_TTL` → `app.memory.max-history` / `app.memory.session-ttl`
+- `RagService.buildContext()` 中 `topK=5` → `app.ai.rag.default-top-k`
+
+#### 0.3 测试基础设施
+
+- 引入 `spring-boot-testcontainers`（PostgreSQL + Redis），替代对外部 Docker 实例的依赖
+- 创建 `AbstractIntegrationTest` 基类，统一管理容器生命周期
+- 为现有两个测试类 (`AgentOrchestratorTest`, `RagControllerValidationTest`) 确认可通过 `mvn test`
+
+#### 0.4 CI Pipeline
+
+- 添加 `.github/workflows/ci.yml`：`mvn test` + 编译检查
+- PR 合入 master 前必须 CI 通过
+
+#### 0.5 Telemetry（Phase 0 部分）
+
+- `ChatService` 新增 `ai.chat.model` tag 到现有 timer，方便后续按模型切片
+
+**交付物**：master 分支代码整洁、CI 绿灯、测试可本地/CI 运行、配置外部化。
+
+---
+
+### Phase 1 — 核心抽象重构
+
+**目标**：解决两个最根本的架构缺陷 — 工具硬编码和输出不可靠。所有后续 Phase 依赖此阶段。
+
+#### 1.1 ToolRegistry 动态注册（GitHub #1）
+
+- 新增 `ToolRegistry` 组件，启动时扫描所有实现 `Function` 接口且标注 `@Component` + `@Description` 的 Bean
+- `AgentOrchestrator.chat()` 改为 `toolNames(toolRegistry.getNames())`
+- `TaskPlanner` 改为 `toolRegistry.getDescriptions()` 生成工具描述
+- 删除 `AgentOrchestrator` 和 `TaskPlanner` 中所有硬编码工具名
+
+**测试**：
+- `ToolRegistryTest` — 验证扫描逻辑、空工具场景、Description 提取
+- 更新 `AgentOrchestratorTest` — 注入 mock ToolRegistry 替代硬编码工具列表
+
+**指标**：
+- `ai.tools.registered.count` (Gauge) — 注册工具数量，启动时上报
+
+#### 1.2 Structured Output 硬约束（GitHub #7）
+
+- `TaskPlanner` 引入 `BeanOutputConverter<List<PlanStep>>`，替换提示词软约束
+- 删除 `TaskPlanner.extractJson()` 手动解析方法
+- 删除 prompt 中的手写 JSON 格式说明
+
+**测试**：
+- `TaskPlannerTest` — 验证正常解析、schema 注入、fallback 降级（LLM 返回非法格式时不崩溃）
+
+**指标**：
+- `ai.planner.result{status=success|fallback}` (Counter) — Planner 成功/降级率
+
+**交付物**：新增工具零改动 Orchestrator；TaskPlanner 输出 100% 可靠反序列化。
+
+---
+
+### Phase 2 — 安全护栏
+
+**目标**：在释放更多 Agent 能力（Phase 3）之前，先把安全边界建好。类比：先装刹车再踩油门。
+
+#### 2.1 maxSteps 硬限制（GitHub #4）
+
+- `ToolExecutionAspect` 在 `proceed()` 前检查 `StepCollector.nextStepNumber()` 是否超过 `app.ai.react.max-steps`
+- 超限时抛出 `MaxStepsExceededException`
+- `AgentOrchestrator` catch 该异常，返回已有部分结果 + 超限提示
+- `ApiExceptionHandler` 增加该异常的 HTTP 映射
+
+**测试**：
+- `ToolExecutionAspectTest` — 模拟连续调用直到超限，验证异常抛出
+- `AgentOrchestratorTest` — 验证超限时返回部分结果而非 500
+
+**指标**：
+- `ai.agent.max_steps_exceeded.total` (Counter) — 超限触发次数
+
+#### 2.2 LLM 调用韧性
+
+- `AgentOrchestrator` 的 `chatClient.prompt().call()` 包装 try-catch，区分：
+  - 超时 (SocketTimeoutException) → 返回友好超时提示
+  - 限流 (429 Too Many Requests) → 返回限流提示
+  - 其他异常 → 统一错误响应
+- 考虑引入 Spring Retry (`@Retryable`) 对瞬时失败自动重试（最多 2 次，指数退避）
+
+**测试**：
+- `AgentOrchestratorTest` — mock ChatClient 抛出各类异常，验证降级行为
+
+**指标**：
+- `ai.error.total{type=timeout|rate_limit|llm_error|unknown}` (Counter) — 按错误类型分类
+
+**交付物**：Agent 不会因 LLM 异常/工具循环而失控；错误有分类、有指标、有降级。
+
+---
+
+### Phase 3 — 能力升级
+
+**目标**：在可靠的地基和安全护栏之上，释放 Agent 的真正能力。
+
+#### 3.1 RAG as a Tool / Agentic RAG Level 1（GitHub #3）
+
+- 新增 `KnowledgeSearchTool` 实现 `Function<Request, Response>`
+  - 内部调用 `RagService.buildContext(query)`
+  - 注册到 ToolRegistry 后自动被 Orchestrator 发现
+- 删除 `ChatService` 中的 `ragEnabled` 预处理逻辑和相关代码路径
+- `ChatRequest.ragEnabled` 字段标记为 `@Deprecated`，保留兼容但不再生效
+- Agent 在 ReAct 循环中自主决定是否检索知识库
+
+**测试**：
+- `KnowledgeSearchToolTest` — mock VectorStore，验证检索与格式化
+- 端到端集成测试 — 验证 Agent 在需要知识时调用该工具，在纯计算时不调用
+
+**指标**：
+- `ai.rag.retrieval.result{result=hit|miss}` (Counter) — RAG 命中率（从 RagService 层上报）
+
+#### 3.2 Streaming SSE（GitHub #2）
+
+- 新增 `GET /api/v1/chat/stream` endpoint，返回 `Flux<ServerSentEvent<String>>`
+- `AgentOrchestrator` 新增 `streamChat()` 方法，使用 `.stream().content()`
+- 原 `POST /api/v1/chat` 保持不变（非破坏性变更）
+- SSE 事件类型设计：
+  - `plan` — TaskPlanner 输出的步骤计划
+  - `step` — 每次工具调用的 AgentStep
+  - `token` — LLM 流式 token
+  - `done` — 最终结果 + 元数据
+
+**测试**：
+- `ChatControllerTest` — WebFlux `StepVerifier` 验证 SSE 事件序列
+- 手动验证 — `curl` + EventSource 确认浏览器可消费
+
+**指标**：
+- `ai.chat.stream.duration` (Timer) — 流式请求端到端耗时
+- `ai.token.input` / `ai.token.output` (Counter) — 从 ChatResponse metadata 提取 token 用量
+
+**交付物**：Agent 具备自主检索能力（不再盲目 RAG）；前端可实时展示推理过程。
+
+---
+
+### Phase 4 — 可观测性收尾 & 全量测试加固
+
+**目标**：补齐前三个 Phase 遗漏的指标盲区，整体测试覆盖率达标。
+
+#### 4.1 Telemetry 查漏补缺（GitHub #5 收尾）
+
+前三个 Phase 已随代码新增了大量指标，此阶段仅处理剩余项：
+- `ai.tool.duration{tool=...}` (Histogram) — ToolExecutionAspect 中按工具名打 tag（如果前面未覆盖）
+- Grafana Dashboard 模板 JSON — 提供开箱即用的仪表盘
+- 验证 Prometheus scrape 配置覆盖所有新增指标
+
+#### 4.2 测试加固（GitHub #6 收尾）
+
+前三个 Phase 已为每个新增/修改的组件编写了测试，此阶段补齐存量代码：
+- `StepCollectorTest` — ThreadLocal 多线程隔离验证
+- `MemoryServiceTest` — Redis 读写、TTL 过期、MAX_HISTORY 截断
+- `ChatControllerTest` — MockMvc 完整 API 契约（含错误码）
+- `ChatServiceTest` — 验证 orchestrator 编排、ragEnabled 降级兼容
+- 目标：核心业务类行覆盖率 ≥ 70%
+
+**交付物**：全链路可观测；`mvn test` 全绿且覆盖率达标。
+
+---
+
+## 执行顺序总览
+
+```
+Phase 0 (地基)     → 分支合并、配置外部化、CI、测试基础设施
+  ↓
+Phase 1 (核心抽象) → #1 ToolRegistry + #7 Structured Output
+  ↓
+Phase 2 (安全护栏) → #4 maxSteps 硬限制 + LLM 调用韧性
+  ↓
+Phase 3 (能力升级) → #3 Agentic RAG + #2 Streaming SSE
+  ↓
+Phase 4 (收尾加固) → #5 Telemetry 补全 + #6 测试覆盖率达标
+```
+
+### 依赖关系
+
+```
+Phase 0 ──→ Phase 1 ──→ Phase 2 ──→ Phase 3 ──→ Phase 4
+                │                       │
+                │  1.1 ToolRegistry ────→ 3.1 RAG as Tool (自动注册)
+                │  1.2 Structured Output (独立)
+                │                       │
+                └───────────────────────→ 3.2 Streaming SSE (独立，仅需 Phase 0 完成)
+```
+
+注：Phase 3 内部 3.1 和 3.2 可并行开发。3.2 Streaming SSE 技术上只依赖 Phase 0，但建议在 Phase 2 安全护栏就位后再做，避免流式场景下循环失控无保护。
+
+---
+
+## 与现有 action-plan 的关键差异
+
+| 维度 | 现有 action-plan | 本计划 |
+|---|---|---|
+| 测试策略 | 最后单独补 (Week 4) | 每个 Phase 自带测试，最后只做查漏 |
+| Telemetry | 独立 Action (Week 3) | 随代码一起长出来，最后只做收尾 |
+| Phase 0 | 无 | 新增：分支合并、CI、配置外部化、测试基础设施 |
+| LLM 韧性 | 未提及 | 新增：错误分类、retry、降级 (Phase 2.2) |
+| 硬编码治理 | 仅提到工具名 | 扩展到 model、memory、RAG topK 等所有散落的魔法值 |
+| SSE 优先级 | P0 (Week 2) | 降为 Phase 3（先有护栏再加能力） |
+| 执行逻辑 | 按"独立性"分组 | 按"依赖链 + 风险"排序：地基→抽象→护栏→能力→收尾 |

--- a/docs/spring-ai-notes-2026-03-19.md
+++ b/docs/spring-ai-notes-2026-03-19.md
@@ -1,0 +1,300 @@
+# Spring AI 学习笔记
+
+> 日期：2026-03-19  
+> 背景：dawn-ai 项目 ReAct 改造后的技术问答整理
+
+---
+
+## 1. Spring AI 是如何调用 Tool 的？
+
+### 工具的两个必要条件
+
+```java
+@Component                                         // ① 注册为 Spring Bean
+@Description("Get current weather...")             // ② 提供描述给 LLM
+public class WeatherTool implements Function<WeatherTool.Request, WeatherTool.Response> {
+    @Override
+    public Response apply(Request request) { ... } // ③ 实现 apply()
+}
+```
+
+**最低要求：`@Component` + `implements Function<Req, Resp>` + `@Description`**
+
+`@Description` 的内容会作为 function description 发给 LLM，LLM 据此判断什么时候该调这个工具。没有它，LLM 不知道工具是干什么的。
+
+### `.toolNames("weatherTool")` 做了什么
+
+```
+.toolNames("weatherTool")
+    ↓
+Spring AI 从 ApplicationContext 按 Bean name 找到 WeatherTool
+    ↓
+反射 Request 的字段（city: String），自动生成 JSON Schema：
+  { "type": "object", "properties": { "city": { "type": "string" } } }
+    ↓
+把 [工具名 + @Description + JSON Schema] 作为 tools 数组发给 OpenAI API
+```
+
+实际发出的 HTTP body 类似：
+```json
+{
+  "tools": [{
+    "type": "function",
+    "function": {
+      "name": "weatherTool",
+      "description": "Get current weather information for a city. Input: city name",
+      "parameters": {
+        "type": "object",
+        "properties": { "city": { "type": "string" } },
+        "required": ["city"]
+      }
+    }
+  }]
+}
+```
+
+### LLM 返回 tool_call 后的执行流程
+
+```
+OpenAI 返回：
+  { "finish_reason": "tool_calls",
+    "tool_calls": [{ "name": "weatherTool", "arguments": "{\"city\":\"beijing\"}" }] }
+    ↓
+Spring AI 解析 arguments JSON → 反序列化为 WeatherTool.Request("beijing")
+    ↓
+调用 weatherTool.apply(request)       ← AOP 在这里拦截（ToolExecutionAspect）
+    ↓
+把 Response 序列化为 JSON 作为 tool message 塞回对话
+    ↓
+再次调用 LLM（带上 tool result）
+    ↓
+LLM 返回 finish_reason = "stop" → 循环终止
+```
+
+### Bean name 的来源
+
+`toolNames("weatherTool")` 里的字符串就是 **Spring Bean 的名字**，默认是类名首字母小写。也可以用 `@Component("myWeather")` 自定义。
+
+**总结：注册为 Bean + 传入 toolNames 就够了**，JSON Schema 是 Spring AI 自动从泛型参数反射生成的，不需要任何额外配置。
+
+---
+
+## 2. `.call().content()` 背后有多少次 LLM 请求？
+
+**一次 `.call().content()` 在代码层面是一行同步阻塞调用，但背后可能是多次 LLM HTTP request。**
+
+以"查询北京天气"为例：
+
+```
+代码调用 .call().content()
+    │
+    ▼  HTTP Request #1 ──────────────────────────────►  OpenAI
+       { messages: [...], tools: [weatherTool, calculatorTool] }
+                                                        LLM 决定调工具
+    ◄────────────────────────────────────────────────
+       { finish_reason: "tool_calls",
+         tool_calls: [{ name: "weatherTool", args: {"city":"beijing"} }] }
+    │
+    ▼  Spring AI 本地执行 weatherTool.apply(...)  （不走网络）
+    │
+    ▼  HTTP Request #2 ──────────────────────────────►  OpenAI
+       { messages: [...原始消息..., tool_call结果] }
+                                                        LLM 总结答案
+    ◄────────────────────────────────────────────────
+       { finish_reason: "stop",
+         content: "北京今天多云，12°C" }
+    │
+    ▼
+返回给代码："北京今天多云，12°C"
+```
+
+### 关键结论
+
+| 维度 | 说明 |
+|------|------|
+| **代码层** | 1 次阻塞调用，`.call()` 不返回直到所有轮次完成 |
+| **LLM Request 层** | N+1 次 HTTP 请求（N = 实际工具调用次数） |
+| **计费层** | 每次 HTTP request 都消耗 token，且越往后消耗越多（消息历史越来越长） |
+| **延迟层** | 总延迟 = Σ 每次 LLM 响应时间，串行累加 |
+
+如果任务需要调 3 个工具，就会产生 4 次 HTTP 请求。这也是为什么要加 `max-steps` 约束的原因。
+
+---
+
+## 3. Spring AI Structured Outputs 三种方案
+
+### 方案一：Prompt 约束（当前 TaskPlanner 用的）
+
+```java
+// 靠 prompt 要求，LLM 不保证遵守，需要自己 extractJson()
+String raw = chatClient.prompt().user(prompt).call().content();
+```
+
+**可靠性：低**，LLM 可能加前缀文字、包 markdown fence、字段名拼错。
+
+---
+
+### 方案二：`BeanOutputConverter` —— Spring AI 的 Prompt 级增强
+
+Spring AI 自动从 Java 类生成 JSON Schema，注入到 prompt 末尾，再做反序列化：
+
+```java
+// 优雅写法：直接用 .entity()
+List<PlanStep> plan = chatClient.prompt()
+    .user(prompt)
+    .call()
+    .entity(new ParameterizedTypeReference<List<PlanStep>>() {});
+```
+
+**底层：** `BeanOutputConverter.getFormat()` 输出 schema 描述追加到 prompt，convert() 做反序列化。  
+**可靠性：中**，本质还是 prompt 约束，但 schema 更精确。
+
+---
+
+### 方案三：OpenAI Structured Outputs —— 模型层硬约束
+
+```java
+import org.springframework.ai.openai.api.ResponseFormat;
+
+OpenAiChatOptions options = OpenAiChatOptions.builder()
+    .responseFormat(ResponseFormat.builder()
+        .type(ResponseFormat.Type.JSON_SCHEMA)   // 关键
+        .jsonSchema(ResponseFormat.JsonSchema.builder()
+            .name("PlanStepList")
+            .schema(converter.getJsonSchemaMap())
+            .strict(true)                        // 严格模式，100% 强制遵守
+            .build())
+        .build())
+    .temperature(0.3)
+    .build();
+```
+
+**底层原理：** schema 放在请求体的 `response_format` 字段，OpenAI 在**模型采样层面**强制约束输出 token 必须符合 schema，LLM 物理上无法输出不合规内容。
+
+`ResponseFormat.Type` 枚举值：`TEXT` / `JSON_OBJECT` / `JSON_SCHEMA`
+
+### 三种方案对比
+
+| | Prompt 约束 | BeanOutputConverter | ResponseFormat JSON_SCHEMA |
+|--|--|--|--|
+| 可靠性 | 低 | 中 | 极高 |
+| 约束层级 | Prompt | Prompt + Schema | 模型采样层 |
+| 需要 schema | 手写 | 自动生成 | 自动生成 |
+| 模型要求 | 无 | 无 | gpt-4o 以上 |
+| 当前项目使用 | ✅ TaskPlanner | ❌ | ❌ |
+
+**建议**：TaskPlanner 可升级到方案三，把 `extractJson()` 的脆弱解析去掉，换成 `strict=true`，输出一定是合法 JSON。
+
+---
+
+## 4. DeepSeek 对三种方案的支持情况
+
+### 支持矩阵
+
+| 模型 | 方案一（Prompt） | 方案二（BeanOutputConverter） | 方案三（JSON_SCHEMA strict） |
+|------|:-:|:-:|:-:|
+| DeepSeek-V3 | ✅ | ✅ | ✅ |
+| DeepSeek-R1 | ✅ | ✅ | ❌ |
+| DeepSeek-V2 | ✅ | ✅ | ❌ |
+
+**DeepSeek-R1 的特殊限制：**  
+R1 是推理模型，内部有 `<think>` 推理链，官方文档明确说明**不建议对 R1 使用 `response_format`**，因为推理过程和结构化输出约束会相互干扰，输出不稳定。
+
+### 切换到 DeepSeek 只需改 yml
+
+```yaml
+spring:
+  ai:
+    openai:
+      api-key: ${DEEPSEEK_API_KEY}
+      base-url: https://api.deepseek.com   # 换 base-url
+      chat:
+        options:
+          model: deepseek-chat             # deepseek-chat = V3
+```
+
+当前项目使用 `spring-ai-starter-model-openai`，DeepSeek API 兼容 OpenAI 格式，`ResponseFormat.JSON_SCHEMA` 参数会原样发给 DeepSeek API，**DeepSeek-V3 能正确处理**。
+
+---
+
+## 5. Agent 是如何判断执行完毕的？
+
+**当前项目没有自己判断「执行是否完毕」，这个判断完全外包给了 Spring AI 框架。**
+
+### Spring AI `.toolNames()` 的内部循环终止条件
+
+Spring AI 在内部实现了一个 tool-calling loop，终止条件由 LLM 自己决定：
+
+```
+LLM 收到消息
+  ↓
+LLM 返回 tool_call（要调 weatherTool）→ 执行工具 → 把结果塞回给 LLM
+  ↓
+LLM 再次推理
+  ↓
+LLM 返回 stop_reason = "stop"（不再调工具）→ 循环退出
+  ↑
+这一步就是"判断完毕"，由 LLM 决定，Spring AI 识别 finish_reason
+```
+
+**LLM 返回 `finish_reason = stop`（而不是 `tool_calls`）时，Spring AI 就认为执行完毕**，把最终文本返回给 `chatClient.prompt()...call().content()`。
+
+### 项目里唯一的"保护机制"是 prompt 级别的软约束
+
+```java
+// AgentOrchestrator.java
++ String.format("%n请在回复中简短说明每次工具调用的原因。最多调用工具 %d 次。", maxSteps);
+```
+
+这只是告诉 LLM「最多 10 次」，**LLM 不一定遵守**，没有代码级别的硬中断。
+
+### 现有风险
+
+| 场景 | 当前行为 |
+|------|---------|
+| LLM 正常工作 | Spring AI 检测到 `finish_reason=stop` 后退出 ✅ |
+| LLM 在工具间无限循环 | 没有代码层硬限制，只靠 prompt 提示 ⚠️ |
+| 工具抛异常 | Spring AI 把异常信息回传给 LLM，LLM 决定是否重试 |
+
+### 如果要做硬性保护
+
+**❌ 错误思路：在 `.call()` 之后检查步骤数**
+
+```java
+// 这无法限制循环次数！
+List<AgentStep> steps = StepCollector.collect();  // .call() 已经返回，循环已结束
+if (steps.size() >= maxSteps) { ... }             // 为时已晚
+```
+
+`.call().content()` 是同步阻塞的黑盒，整个 ReAct 循环在内部完成后才返回，`collect()` 只能用于**观测**，不能用于**控制**。
+
+**✅ 正确方案：在 AOP 切面里拦截**
+
+AOP 切面在 Spring AI 工具调用**中途**执行，是真正能"插入"循环的位置。当超限时，不调用 `pjp.proceed()`，直接返回终止信号给 LLM：
+
+```java
+// ToolExecutionAspect.java
+@Around("execution(* com.dawn.ai.agent.tools.*.apply(..))")
+public Object captureStep(ProceedingJoinPoint pjp) throws Throwable {
+    int stepNum = StepCollector.nextStepNumber();
+
+    // 超限时不执行工具，返回停止信号给 LLM
+    if (stepNum > StepCollector.getMaxSteps()) {
+        log.warn("[ReAct] 已达到 maxSteps 上限，返回终止信号");
+        return "已达到最大工具调用次数限制，请根据已有信息直接给出最终答案，不要再调用工具。";
+    }
+
+    // 正常执行
+    long start = System.currentTimeMillis();
+    Object result = pjp.proceed();
+    // ...
+}
+```
+
+LLM 收到这个字符串作为工具返回值，会自然地产出最终答案（`finish_reason=stop`），循环终止。  
+`maxSteps` 通过 `StepCollector` 的 ThreadLocal 传递（在 `init(maxSteps)` 时存入）。
+
+| | AOP 返回终止信号（推荐）| 抛异常强制中断 |
+|--|--|--|
+| LLM 能否产出最终答案 | ✅ 基于已有结果总结 | ❌ 直接截断 |
+| 代码侵入性 | 低 | 中 |

--- a/pom.xml
+++ b/pom.xml
@@ -97,6 +97,12 @@
             <optional>true</optional>
         </dependency>
 
+        <!-- AOP — enables @Aspect for ToolExecutionAspect -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-aop</artifactId>
+        </dependency>
+
         <!-- Validation -->
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/src/main/java/com/dawn/ai/agent/AgentOrchestrator.java
+++ b/src/main/java/com/dawn/ai/agent/AgentOrchestrator.java
@@ -1,7 +1,5 @@
 package com.dawn.ai.agent;
 
-import com.dawn.ai.agent.tools.CalculatorTool;
-import com.dawn.ai.agent.tools.WeatherTool;
 import com.dawn.ai.service.MemoryService;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Timer;
@@ -11,21 +9,25 @@ import org.springframework.ai.chat.client.ChatClient;
 import org.springframework.ai.chat.messages.AssistantMessage;
 import org.springframework.ai.chat.messages.Message;
 import org.springframework.ai.chat.messages.UserMessage;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
+import java.util.stream.Collectors;
 
 /**
- * Agent Orchestrator — the brain of the ReAct loop.
+ * Agent Orchestrator — orchestrates the full ReAct loop with planning and step tracing.
  *
- * Design Analogy:
- * Think of this as a Thread Pool Manager using ReentrantLock + Condition:
- *  - The LLM is the "main thread" that decides which "worker thread" (Tool) to invoke.
- *  - Tools are like Callable tasks submitted to an executor — they run, return results,
- *    and the LLM synthesizes the final answer from all tool outputs.
- *  - Memory history is the shared state, protected conceptually like a concurrent queue.
+ * Flow per request:
+ *  1. StepCollector.init()         — reset thread-local state
+ *  2. TaskPlanner.plan()           — pre-execution planning via a separate LLM call (optional)
+ *  3. Build system prompt          — base prompt + plan summary + max-steps instruction
+ *  4. chatClient + .toolNames()    — Spring AI handles the tool-calling loop
+ *  5. ToolExecutionAspect (AOP)    — intercepts each tool call, records it automatically
+ *  6. StepCollector.collect()      — gather all recorded steps
+ *  7. Mark plan steps completed    — correlate plan with actual tool calls
+ *  8. Persist to memory            — save turn to Redis
+ *  9. StepCollector.clear()        — prevent ThreadLocal memory leak
  */
 @Slf4j
 @Service
@@ -34,37 +36,74 @@ public class AgentOrchestrator {
 
     private final ChatClient chatClient;
     private final MemoryService memoryService;
-    private final WeatherTool weatherTool;
-    private final CalculatorTool calculatorTool;
+    private final TaskPlanner taskPlanner;
     private final MeterRegistry meterRegistry;
 
-    public String chat(String sessionId, String userMessage) {
+    @Value("${app.ai.system-prompt:You are a helpful AI assistant.}")
+    private String baseSystemPrompt;
+
+    @Value("${app.ai.react.max-steps:10}")
+    private int maxSteps;
+
+    @Value("${app.ai.react.plan-enabled:true}")
+    private boolean planEnabled;
+
+    public AgentResult chat(String sessionId, String userMessage) {
         return Timer.builder("ai.agent.chat.duration")
                 .tag("session", "anonymous")
                 .register(meterRegistry)
                 .record(() -> doChat(sessionId, userMessage));
     }
 
-    private String doChat(String sessionId, String userMessage) {
-        // 1. Build conversation history without duplicating the current turn
-        List<Message> history = buildHistory(sessionId);
+    private AgentResult doChat(String sessionId, String userMessage) {
+        // ① Reset per-request step tracking
+        StepCollector.init();
+        try {
+            // ② Optional pre-execution planning
+            List<PlanStep> plan;
+            if (planEnabled) {
+                plan = taskPlanner.plan(userMessage, getToolDescriptions());
+            } else {
+                plan = Collections.emptyList();
+            }
 
-        // 2. Call LLM with prior history plus the current user turn
-        String response = chatClient.prompt()
-                .messages(history)
-                .user(userMessage)
-                .toolNames("weatherTool", "calculatorTool")
-                .call()
-                .content();
+            // ③ Compose system prompt: base + plan summary + max-steps hint
+            String systemPrompt = baseSystemPrompt
+                    + formatPlan(plan)
+                    + String.format("%n请在回复中简短说明每次工具调用的原因。最多调用工具 %d 次。", maxSteps);
 
-        // 3. Persist the completed turn after a successful model call
-        memoryService.addMessage(sessionId, "user", userMessage);
-        memoryService.addMessage(sessionId, "assistant", response);
+            // ④ Load conversation history
+            List<Message> history = buildHistory(sessionId);
 
-        log.info("[AgentOrchestrator] session={}, userMsg={}, responseLen={}",
-                sessionId, userMessage.substring(0, Math.min(50, userMessage.length())), response.length());
+            // ⑤ LLM call — AOP intercepts tool invocations inside this call
+            String response = chatClient.prompt()
+                    .system(systemPrompt)
+                    .messages(history)
+                    .user(userMessage)
+                    .toolNames("weatherTool", "calculatorTool")
+                    .call()
+                    .content();
 
-        return response;
+            // ⑥ Collect the steps recorded by ToolExecutionAspect
+            List<AgentStep> steps = StepCollector.collect();
+
+            // ⑦ Mark which plan steps were fulfilled
+            markPlanStepsCompleted(plan, steps);
+
+            // ⑧ Persist turn to memory
+            memoryService.addMessage(sessionId, "user", userMessage);
+            memoryService.addMessage(sessionId, "assistant", response);
+
+            log.info("[AgentOrchestrator] session={}, planSteps={}, toolCalls={}, userMsg={}",
+                    sessionId, plan.size(), steps.size(),
+                    userMessage.substring(0, Math.min(50, userMessage.length())));
+
+            return new AgentResult(response, steps, plan);
+
+        } finally {
+            // ⑨ Always clean up to prevent ThreadLocal memory leaks
+            StepCollector.clear();
+        }
     }
 
     private List<Message> buildHistory(String sessionId) {
@@ -80,5 +119,36 @@ public class AgentOrchestrator {
             }
         }
         return messages;
+    }
+
+    private Map<String, String> getToolDescriptions() {
+        Map<String, String> tools = new LinkedHashMap<>();
+        tools.put("weatherTool", "查询指定城市的当前天气信息（温度、天气状况）");
+        tools.put("calculatorTool", "执行数学计算，支持加减乘除和括号表达式");
+        return tools;
+    }
+
+    /** Formats the plan into a human-readable block for the system prompt. */
+    private String formatPlan(List<PlanStep> plan) {
+        if (plan.isEmpty()) return "";
+        StringBuilder sb = new StringBuilder("\n\n【执行计划】\n");
+        for (PlanStep step : plan) {
+            sb.append(step.getStepNumber())
+              .append(". [").append(step.getAction()).append("] ")
+              .append(step.getReason()).append("\n");
+        }
+        return sb.toString();
+    }
+
+    /** Marks plan steps as completed based on which tools were actually invoked. */
+    private void markPlanStepsCompleted(List<PlanStep> plan, List<AgentStep> steps) {
+        Set<String> usedTools = steps.stream()
+                .map(AgentStep::toolName)
+                .collect(Collectors.toSet());
+        for (PlanStep planStep : plan) {
+            if (usedTools.contains(planStep.getAction()) || "finish".equals(planStep.getAction())) {
+                planStep.setCompleted(true);
+            }
+        }
     }
 }

--- a/src/main/java/com/dawn/ai/agent/AgentOrchestrator.java
+++ b/src/main/java/com/dawn/ai/agent/AgentOrchestrator.java
@@ -37,6 +37,7 @@ public class AgentOrchestrator {
     private final ChatClient chatClient;
     private final MemoryService memoryService;
     private final TaskPlanner taskPlanner;
+    private final ToolRegistry toolRegistry;
     private final MeterRegistry meterRegistry;
 
     @Value("${app.ai.system-prompt:You are a helpful AI assistant.}")
@@ -62,7 +63,7 @@ public class AgentOrchestrator {
             // ② Optional pre-execution planning
             List<PlanStep> plan;
             if (planEnabled) {
-                plan = taskPlanner.plan(userMessage, getToolDescriptions());
+                plan = taskPlanner.plan(userMessage, toolRegistry.getDescriptions());
             } else {
                 plan = Collections.emptyList();
             }
@@ -80,7 +81,7 @@ public class AgentOrchestrator {
                     .system(systemPrompt)
                     .messages(history)
                     .user(userMessage)
-                    .toolNames("weatherTool", "calculatorTool")
+                    .toolNames(toolRegistry.getNames())
                     .call()
                     .content();
 
@@ -119,13 +120,6 @@ public class AgentOrchestrator {
             }
         }
         return messages;
-    }
-
-    private Map<String, String> getToolDescriptions() {
-        Map<String, String> tools = new LinkedHashMap<>();
-        tools.put("weatherTool", "查询指定城市的当前天气信息（温度、天气状况）");
-        tools.put("calculatorTool", "执行数学计算，支持加减乘除和括号表达式");
-        return tools;
     }
 
     /** Formats the plan into a human-readable block for the system prompt. */

--- a/src/main/java/com/dawn/ai/agent/AgentResult.java
+++ b/src/main/java/com/dawn/ai/agent/AgentResult.java
@@ -1,0 +1,12 @@
+package com.dawn.ai.agent;
+
+import java.util.List;
+
+/**
+ * Return type of AgentOrchestrator.chat(), replacing the bare String.
+ */
+public record AgentResult(
+        String finalAnswer,
+        List<AgentStep> steps,
+        List<PlanStep> plan
+) {}

--- a/src/main/java/com/dawn/ai/agent/AgentStep.java
+++ b/src/main/java/com/dawn/ai/agent/AgentStep.java
@@ -1,0 +1,9 @@
+package com.dawn.ai.agent;
+
+public record AgentStep(
+        int stepNumber,
+        String toolName,
+        Object toolInput,
+        String toolOutput,
+        long durationMs
+) {}

--- a/src/main/java/com/dawn/ai/agent/PlanStep.java
+++ b/src/main/java/com/dawn/ai/agent/PlanStep.java
@@ -1,0 +1,16 @@
+package com.dawn.ai.agent;
+
+import lombok.Data;
+
+/**
+ * A single step in the pre-execution plan.
+ * Uses a regular class (not record) because completed/result are mutated during execution.
+ */
+@Data
+public class PlanStep {
+    private final int stepNumber;
+    private final String action;   // tool name or "finish" for the last step
+    private final String reason;
+    private boolean completed = false;
+    private String result;
+}

--- a/src/main/java/com/dawn/ai/agent/StepCollector.java
+++ b/src/main/java/com/dawn/ai/agent/StepCollector.java
@@ -1,0 +1,47 @@
+package com.dawn.ai.agent;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * ThreadLocal-based request-scoped step collector.
+ * Bridges ToolExecutionAspect and AgentOrchestrator without touching tool classes.
+ *
+ * Lifecycle per request:
+ *   AgentOrchestrator.doChat() calls init() → AOP records steps → collect() → clear()
+ */
+public class StepCollector {
+
+    private static final ThreadLocal<List<AgentStep>> STEPS =
+            ThreadLocal.withInitial(ArrayList::new);
+    private static final ThreadLocal<AtomicInteger> COUNTER =
+            ThreadLocal.withInitial(() -> new AtomicInteger(0));
+
+    /** Call at the start of each request to reset state from any previous run. */
+    public static void init() {
+        STEPS.get().clear();
+        COUNTER.get().set(0);
+    }
+
+    /** Called by ToolExecutionAspect after each tool invocation. */
+    public static void record(AgentStep step) {
+        STEPS.get().add(step);
+    }
+
+    /** Returns the next monotonically increasing step number for the current request. */
+    public static int nextStepNumber() {
+        return COUNTER.get().incrementAndGet();
+    }
+
+    /** Returns a snapshot of all recorded steps for the current request. */
+    public static List<AgentStep> collect() {
+        return new ArrayList<>(STEPS.get());
+    }
+
+    /** Must be called in a finally block to prevent ThreadLocal memory leaks. */
+    public static void clear() {
+        STEPS.remove();
+        COUNTER.remove();
+    }
+}

--- a/src/main/java/com/dawn/ai/agent/TaskPlanner.java
+++ b/src/main/java/com/dawn/ai/agent/TaskPlanner.java
@@ -1,0 +1,105 @@
+package com.dawn.ai.agent;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.ai.chat.client.ChatClient;
+import org.springframework.ai.openai.OpenAiChatOptions;
+import org.springframework.stereotype.Service;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * Generates a structured execution plan before the main ReAct loop.
+ *
+ * The planning call is completely independent from the conversation history:
+ * it needs a low-temperature, global view of the task, not a contextual one.
+ * Failure is non-fatal — the orchestrator degrades gracefully to no-plan mode.
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class TaskPlanner {
+
+    private final ChatClient chatClient;
+    private final ObjectMapper objectMapper;
+
+    /**
+     * Plans the steps required to complete {@code task} given the available tools.
+     *
+     * @param task                 the user's request
+     * @param toolDescriptions     map of tool name → description
+     * @return ordered plan steps, or an empty list on any failure
+     */
+    public List<PlanStep> plan(String task, Map<String, String> toolDescriptions) {
+        String prompt = buildPlanPrompt(task, toolDescriptions);
+        try {
+            String raw = chatClient.prompt()
+                    .user(prompt)
+                    .options(OpenAiChatOptions.builder().temperature(0.3).build())
+                    .call()
+                    .content();
+
+            String json = extractJson(raw);
+            List<Map<String, Object>> rawSteps = objectMapper.readValue(
+                    json, new TypeReference<List<Map<String, Object>>>() {});
+
+            List<PlanStep> plan = rawSteps.stream()
+                    .map(m -> new PlanStep(
+                            ((Number) m.get("step")).intValue(),
+                            String.valueOf(m.get("action")),
+                            String.valueOf(m.get("reason"))))
+                    .collect(Collectors.toList());
+
+            log.debug("[TaskPlanner] Generated {} steps for task: {}", plan.size(),
+                    task.substring(0, Math.min(50, task.length())));
+            return plan;
+
+        } catch (Exception e) {
+            log.warn("[TaskPlanner] Planning failed, falling back to no-plan mode: {}", e.getMessage());
+            return Collections.emptyList();
+        }
+    }
+
+    private String buildPlanPrompt(String task, Map<String, String> toolDescriptions) {
+        String toolList = toolDescriptions.entrySet().stream()
+                .map(e -> "- " + e.getKey() + ": " + e.getValue())
+                .collect(Collectors.joining("\n"));
+
+        return """
+                你是一个任务规划助手。请分析用户的任务，生成一个 2-5 步的执行计划。
+                
+                可用工具：
+                %s
+                
+                严格以 JSON 数组格式返回，每项包含：
+                - step: 步骤编号（从 1 开始）
+                - action: 工具名称（从上方可用工具中选择），最后一步固定为 "finish"
+                - reason: 使用该工具的原因（中文，简短）
+                
+                要求：
+                - 只返回 JSON 数组，不要其他文字
+                - 最后一步必须是 {"step": N, "action": "finish", "reason": "完成任务"}
+                
+                用户任务：%s
+                
+                示例格式：
+                [{"step":1,"action":"weatherTool","reason":"查询北京当前天气"},{"step":2,"action":"finish","reason":"完成任务"}]
+                """.formatted(toolList, task);
+    }
+
+    /** Extracts the JSON array from LLM output that may contain markdown fences. */
+    private String extractJson(String raw) {
+        String trimmed = raw.trim();
+        int start = trimmed.indexOf('[');
+        int end = trimmed.lastIndexOf(']');
+        if (start >= 0 && end > start) {
+            return trimmed.substring(start, end + 1);
+        }
+        return trimmed;
+    }
+}

--- a/src/main/java/com/dawn/ai/agent/ToolRegistry.java
+++ b/src/main/java/com/dawn/ai/agent/ToolRegistry.java
@@ -1,0 +1,65 @@
+package com.dawn.ai.agent;
+
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.Description;
+import org.springframework.stereotype.Component;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.function.Function;
+
+/**
+ * Auto-discovers all Tool beans in com.dawn.ai.agent.tools at startup.
+ *
+ * A Tool is any Spring bean that:
+ *   1. Implements java.util.function.Function
+ *   2. Is annotated with @Description
+ *   3. Lives under the com.dawn.ai.agent.tools package
+ *
+ * This eliminates the dual maintenance of toolNames() and getToolDescriptions()
+ * in AgentOrchestrator and TaskPlanner. New tools are picked up automatically.
+ */
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class ToolRegistry {
+
+    private static final String TOOLS_PACKAGE = "com.dawn.ai.agent.tools";
+
+    private final ApplicationContext applicationContext;
+
+    /** Insertion-ordered map: bean name → @Description value */
+    private Map<String, String> tools = Collections.emptyMap();
+
+    @PostConstruct
+    void discover() {
+        Map<String, String> discovered = new LinkedHashMap<>();
+
+        applicationContext.getBeansWithAnnotation(Description.class).forEach((beanName, bean) -> {
+            if (bean instanceof Function<?, ?>
+                    && bean.getClass().getPackageName().startsWith(TOOLS_PACKAGE)) {
+                String description = bean.getClass().getAnnotation(Description.class).value();
+                discovered.put(beanName, description);
+                log.info("[ToolRegistry] Registered tool: {} — {}", beanName, description);
+            }
+        });
+
+        this.tools = Collections.unmodifiableMap(discovered);
+        log.info("[ToolRegistry] Discovery complete. {} tool(s) registered: {}",
+                tools.size(), tools.keySet());
+    }
+
+    /** Returns tool bean names for use with chatClient.toolNames(). */
+    public String[] getNames() {
+        return tools.keySet().toArray(String[]::new);
+    }
+
+    /** Returns tool name → description map for use in TaskPlanner prompts. */
+    public Map<String, String> getDescriptions() {
+        return tools;
+    }
+}

--- a/src/main/java/com/dawn/ai/agent/ToolRegistry.java
+++ b/src/main/java/com/dawn/ai/agent/ToolRegistry.java
@@ -3,8 +3,10 @@ package com.dawn.ai.agent;
 import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.aop.support.AopUtils;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Description;
+import org.springframework.core.annotation.AnnotationUtils;
 import org.springframework.stereotype.Component;
 
 import java.util.Collections;
@@ -40,11 +42,19 @@ public class ToolRegistry {
         Map<String, String> discovered = new LinkedHashMap<>();
 
         applicationContext.getBeansWithAnnotation(Description.class).forEach((beanName, bean) -> {
+            // 1. Safely unwrap the proxy to get the real target class
+            Class<?> targetClass = AopUtils.getTargetClass(bean);
+
             if (bean instanceof Function<?, ?>
-                    && bean.getClass().getPackageName().startsWith(TOOLS_PACKAGE)) {
-                String description = bean.getClass().getAnnotation(Description.class).value();
-                discovered.put(beanName, description);
-                log.info("[ToolRegistry] Registered tool: {} — {}", beanName, description);
+                    && targetClass.getPackageName().startsWith(TOOLS_PACKAGE)) {
+                Description descriptionAnnotation = AnnotationUtils.findAnnotation(targetClass, Description.class);
+                if (descriptionAnnotation == null) {
+                    log.warn("[ToolRegistry] Skipping tool '{}' ({}): missing @Description on target class",
+                            beanName, targetClass.getName());
+                    return;
+                }
+                discovered.put(beanName, descriptionAnnotation.value());
+                log.info("[ToolRegistry] Registered tool: {} — {}", beanName, descriptionAnnotation.value());
             }
         });
 

--- a/src/main/java/com/dawn/ai/agent/aop/ToolExecutionAspect.java
+++ b/src/main/java/com/dawn/ai/agent/aop/ToolExecutionAspect.java
@@ -1,0 +1,40 @@
+package com.dawn.ai.agent.aop;
+
+import com.dawn.ai.agent.AgentStep;
+import com.dawn.ai.agent.StepCollector;
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.springframework.stereotype.Component;
+
+/**
+ * Intercepts every tool invocation in the agent tools package and records it as an AgentStep.
+ *
+ * The pointcut covers all current and future tools under com.dawn.ai.agent.tools,
+ * so new tools are automatically traced without any modification.
+ */
+@Slf4j
+@Aspect
+@Component
+public class ToolExecutionAspect {
+
+    @Around("execution(* com.dawn.ai.agent.tools.*.apply(..))")
+    public Object captureStep(ProceedingJoinPoint pjp) throws Throwable {
+        String toolName = pjp.getTarget().getClass().getSimpleName();
+        Object input = pjp.getArgs()[0];
+        long start = System.currentTimeMillis();
+
+        Object result = pjp.proceed();
+
+        long durationMs = System.currentTimeMillis() - start;
+        int stepNum = StepCollector.nextStepNumber();
+
+        StepCollector.record(new AgentStep(stepNum, toolName, input, result.toString(), durationMs));
+
+        log.debug("[ReAct] Step {} | tool={} | input={} | output={} | {}ms",
+                stepNum, toolName, input, result, durationMs);
+
+        return result;
+    }
+}

--- a/src/main/java/com/dawn/ai/config/AiAvailabilityChecker.java
+++ b/src/main/java/com/dawn/ai/config/AiAvailabilityChecker.java
@@ -17,7 +17,7 @@ public class AiAvailabilityChecker {
 
     public void ensureConfigured() {
         if (openAiApiKey == null || openAiApiKey.isBlank() || PLACEHOLDER_API_KEY.equals(openAiApiKey)) {
-            throw new AiConfigurationException("OpenAI API key is not configured. Set OPENAI_API_KEY before calling AI or RAG endpoints.");
+            throw new AiConfigurationException("AI API key is not configured. Set DEEPSEEK_API_KEY or OPENAI_API_KEY before calling AI or RAG endpoints.");
         }
     }
 }

--- a/src/main/java/com/dawn/ai/config/AiConfig.java
+++ b/src/main/java/com/dawn/ai/config/AiConfig.java
@@ -2,17 +2,28 @@ package com.dawn.ai.config;
 
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Timer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.ai.chat.client.ChatClient;
 import org.springframework.ai.chat.model.ChatModel;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.ApplicationRunner;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
 public class AiConfig {
 
+    private static final Logger log = LoggerFactory.getLogger(AiConfig.class);
+
     @Value("${app.ai.system-prompt:You are a helpful AI assistant.}")
     private String defaultSystemPrompt;
+
+    @Value("${spring.ai.openai.base-url:}")
+    private String openAiBaseUrl;
+
+    @Value("${spring.ai.openai.api-key:}")
+    private String openAiApiKey;
 
     @Bean
     public ChatClient chatClient(ChatModel chatModel) {
@@ -27,5 +38,23 @@ public class AiConfig {
                 .description("Duration of AI chat requests")
                 .tag("model", "openai")
                 .register(registry);
+    }
+
+    @Bean
+    public ApplicationRunner aiStartupLogRunner() {
+        return args -> log.info("[AI Config] base-url={}, api-key={}",
+                openAiBaseUrl,
+                maskApiKey(openAiApiKey));
+    }
+
+    private String maskApiKey(String apiKey) {
+        if (apiKey == null || apiKey.isBlank()) {
+            return "<empty>";
+        }
+        if (apiKey.length() <= 8) {
+            return "***" + apiKey.length();
+        }
+        return apiKey.substring(0, 4) + "..." + apiKey.substring(apiKey.length() - 4)
+                + " (len=" + apiKey.length() + ")";
     }
 }

--- a/src/main/java/com/dawn/ai/config/AiConfig.java
+++ b/src/main/java/com/dawn/ai/config/AiConfig.java
@@ -42,9 +42,14 @@ public class AiConfig {
 
     @Bean
     public ApplicationRunner aiStartupLogRunner() {
-        return args -> log.info("[AI Config] base-url={}, api-key={}",
-                openAiBaseUrl,
-                maskApiKey(openAiApiKey));
+        return args -> {
+            log.info("[AI Config] base-url={}, api-key={}",
+                    openAiBaseUrl,
+                    maskApiKey(openAiApiKey));
+            if (openAiBaseUrl != null && openAiBaseUrl.endsWith("/v1")) {
+                log.warn("[AI Config] base-url ends with /v1. Spring AI will append /v1/chat/completions automatically, which can produce a duplicated /v1 path for OpenAI-compatible providers.");
+            }
+        };
     }
 
     private String maskApiKey(String apiKey) {

--- a/src/main/java/com/dawn/ai/dto/ChatResponse.java
+++ b/src/main/java/com/dawn/ai/dto/ChatResponse.java
@@ -1,7 +1,10 @@
 package com.dawn.ai.dto;
 
+import com.dawn.ai.agent.AgentStep;
 import lombok.Builder;
 import lombok.Data;
+
+import java.util.List;
 
 @Data
 @Builder
@@ -10,4 +13,7 @@ public class ChatResponse {
     private String answer;
     private long durationMs;
     private String model;
+    private List<AgentStep> steps;    // tool call details; null when show-steps=false
+    private String planSummary;       // e.g. "步骤1: weatherTool → 步骤2: 完成"
+    private int totalSteps;           // number of tool calls actually made
 }

--- a/src/main/java/com/dawn/ai/exception/ApiExceptionHandler.java
+++ b/src/main/java/com/dawn/ai/exception/ApiExceptionHandler.java
@@ -27,10 +27,10 @@ public class ApiExceptionHandler {
     public ResponseEntity<Map<String, Object>> handleRestClient(
             RestClientException exception,
             HttpServletRequest request) {
-        String message = "AI provider request failed. Verify OPENAI_API_KEY and outbound network access.";
+        String message = "AI provider request failed. Verify DEEPSEEK_API_KEY/OPENAI_API_KEY, base URL, and outbound network access.";
         Throwable cause = exception.getCause();
         if (cause instanceof HttpRetryException) {
-            message = "AI provider authentication failed. Verify OPENAI_API_KEY before retrying.";
+            message = "AI provider authentication failed. Verify DEEPSEEK_API_KEY/OPENAI_API_KEY and spring.ai.openai.base-url before retrying.";
         }
 
         return buildResponse(HttpStatus.BAD_GATEWAY, message, request.getRequestURI());

--- a/src/main/java/com/dawn/ai/service/ChatService.java
+++ b/src/main/java/com/dawn/ai/service/ChatService.java
@@ -1,15 +1,20 @@
 package com.dawn.ai.service;
 
+import com.dawn.ai.agent.AgentResult;
 import com.dawn.ai.agent.AgentOrchestrator;
+import com.dawn.ai.agent.PlanStep;
 import com.dawn.ai.config.AiAvailabilityChecker;
 import com.dawn.ai.dto.ChatRequest;
 import com.dawn.ai.dto.ChatResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.ai.chat.client.ChatClient;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 @Slf4j
 @Service
@@ -21,19 +26,20 @@ public class ChatService {
     private final ChatClient chatClient;
     private final AiAvailabilityChecker aiAvailabilityChecker;
 
+    @Value("${app.ai.react.show-steps:false}")
+    private boolean showSteps;
+
     public ChatResponse chat(ChatRequest request) {
         long start = System.currentTimeMillis();
 
         aiAvailabilityChecker.ensureConfigured();
 
-        // Generate or reuse session ID for conversation continuity
         String sessionId = (request.getSessionId() != null && !request.getSessionId().isBlank())
                 ? request.getSessionId()
                 : UUID.randomUUID().toString();
 
         String userMessage = request.getMessage();
 
-        // If RAG is enabled, prepend retrieved context to the user message
         if (request.isRagEnabled()) {
             String context = ragService.buildContext(userMessage);
             if (!context.isBlank()) {
@@ -41,11 +47,14 @@ public class ChatService {
             }
         }
 
-        String answer = agentOrchestrator.chat(sessionId, userMessage);
+        AgentResult result = agentOrchestrator.chat(sessionId, userMessage);
 
         return ChatResponse.builder()
                 .sessionId(sessionId)
-                .answer(answer)
+                .answer(result.finalAnswer())
+                .steps(showSteps ? result.steps() : null)
+                .planSummary(formatPlanSummary(result.plan()))
+                .totalSteps(result.steps().size())
                 .durationMs(System.currentTimeMillis() - start)
                 .model("gpt-4o")
                 .build();
@@ -59,5 +68,13 @@ public class ChatService {
                 .user(message)
                 .call()
                 .content();
+    }
+
+    /** Formats the plan as a concise human-readable summary, e.g. "步骤1: weatherTool → 步骤2: 完成". */
+    private String formatPlanSummary(List<PlanStep> plan) {
+        if (plan == null || plan.isEmpty()) return "";
+        return plan.stream()
+                .map(s -> "步骤" + s.getStepNumber() + ": " + s.getAction())
+                .collect(Collectors.joining(" → "));
     }
 }

--- a/src/main/java/com/dawn/ai/service/ChatService.java
+++ b/src/main/java/com/dawn/ai/service/ChatService.java
@@ -29,6 +29,9 @@ public class ChatService {
     @Value("${app.ai.react.show-steps:false}")
     private boolean showSteps;
 
+    @Value("${spring.ai.openai.chat.options.model:qwen-plus}")
+    private String model;
+
     public ChatResponse chat(ChatRequest request) {
         long start = System.currentTimeMillis();
 
@@ -56,7 +59,7 @@ public class ChatService {
                 .planSummary(formatPlanSummary(result.plan()))
                 .totalSteps(result.steps().size())
                 .durationMs(System.currentTimeMillis() - start)
-                .model("gpt-4o")
+                .model(model)
                 .build();
     }
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -29,7 +29,7 @@ spring:
       base-url: ${BASE_URL:https://api.deepseek.com}
       chat:
         options:
-          model: deepseek-chat
+          model: ${MODEL:deepseek-chat}
           temperature: 0.7
           max-tokens: 2048
       embedding:
@@ -66,7 +66,7 @@ app:
   ai:
     react:
       max-steps: 10        # 单次对话最多工具调用次数（超出时 LLM 自行收敛）
-      show-steps: false    # 响应体中是否包含 steps 详情
+      show-steps: true    # 响应体中是否包含 steps 详情
       plan-enabled: true   # 是否启用执行前规划（关闭后跳过 TaskPlanner）
     system-prompt: |
       You are Dawn AI, a helpful and knowledgeable assistant powered by advanced AI.

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -26,9 +26,10 @@ spring:
   ai:
     openai:
       api-key: ${OPENAI_API_KEY:your-api-key-here}
+      base-url: ${BASE_URL:https://api.deepseek.com}
       chat:
         options:
-          model: gpt-4o
+          model: deepseek-chat
           temperature: 0.7
           max-tokens: 2048
       embedding:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -63,10 +63,15 @@ management:
 # Application config
 app:
   ai:
+    react:
+      max-steps: 10        # 单次对话最多工具调用次数（超出时 LLM 自行收敛）
+      show-steps: false    # 响应体中是否包含 steps 详情
+      plan-enabled: true   # 是否启用执行前规划（关闭后跳过 TaskPlanner）
     system-prompt: |
       You are Dawn AI, a helpful and knowledgeable assistant powered by advanced AI.
       You can help with calculations, weather queries, and answer questions based on your knowledge base.
       Always be concise, accurate, and helpful.
+      Before calling a tool, briefly explain your reasoning in one sentence.
 
 logging:
   level:

--- a/src/test/java/com/dawn/ai/agent/AgentOrchestratorTest.java
+++ b/src/test/java/com/dawn/ai/agent/AgentOrchestratorTest.java
@@ -1,7 +1,5 @@
 package com.dawn.ai.agent;
 
-import com.dawn.ai.agent.tools.CalculatorTool;
-import com.dawn.ai.agent.tools.WeatherTool;
 import com.dawn.ai.service.MemoryService;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.junit.jupiter.api.BeforeEach;
@@ -13,6 +11,7 @@ import org.springframework.ai.chat.client.ChatClient;
 import org.springframework.ai.chat.messages.Message;
 import org.springframework.ai.chat.messages.UserMessage;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -26,32 +25,29 @@ class AgentOrchestratorTest {
 
     private AgentOrchestrator agentOrchestrator;
 
-    @Mock
-    private ChatClient chatClient;
-
-    @Mock
-    private ChatClient.ChatClientRequestSpec requestSpec;
-
-    @Mock
-    private ChatClient.CallResponseSpec callResponseSpec;
-
-    @Mock
-    private MemoryService memoryService;
-
-    @Mock
-    private WeatherTool weatherTool;
-
-    @Mock
-    private CalculatorTool calculatorTool;
+    @Mock private ChatClient chatClient;
+    @Mock private ChatClient.ChatClientRequestSpec requestSpec;
+    @Mock private ChatClient.CallResponseSpec callResponseSpec;
+    @Mock private MemoryService memoryService;
+    @Mock private TaskPlanner taskPlanner;
+    @Mock private ToolRegistry toolRegistry;
 
     @BeforeEach
     void setUp() {
         MockitoAnnotations.openMocks(this);
+
+        when(toolRegistry.getNames()).thenReturn(new String[]{"weatherTool", "calculatorTool"});
+        when(toolRegistry.getDescriptions()).thenReturn(Map.of(
+                "weatherTool", "查询天气",
+                "calculatorTool", "数学计算"
+        ));
+        when(taskPlanner.plan(anyString(), any())).thenReturn(Collections.emptyList());
+
         agentOrchestrator = new AgentOrchestrator(
                 chatClient,
                 memoryService,
-                weatherTool,
-                calculatorTool,
+                taskPlanner,
+                toolRegistry,
                 new SimpleMeterRegistry()
         );
     }
@@ -61,13 +57,14 @@ class AgentOrchestratorTest {
         when(memoryService.getHistory("session-1"))
                 .thenReturn(List.of(Map.of("role", "assistant", "content", "previous reply")));
         when(chatClient.prompt()).thenReturn(requestSpec);
+        when(requestSpec.system(anyString())).thenReturn(requestSpec);
         when(requestSpec.messages(any(List.class))).thenReturn(requestSpec);
         when(requestSpec.user(anyString())).thenReturn(requestSpec);
         when(requestSpec.toolNames(any(String[].class))).thenReturn(requestSpec);
         when(requestSpec.call()).thenReturn(callResponseSpec);
         when(callResponseSpec.content()).thenReturn("final answer");
 
-        String response = agentOrchestrator.chat("session-1", "current question");
+        AgentResult result = agentOrchestrator.chat("session-1", "current question");
 
         ArgumentCaptor<List<Message>> historyCaptor = ArgumentCaptor.forClass(List.class);
         verify(requestSpec).messages(historyCaptor.capture());
@@ -75,7 +72,7 @@ class AgentOrchestratorTest {
         verify(memoryService).addMessage("session-1", "user", "current question");
         verify(memoryService).addMessage("session-1", "assistant", "final answer");
 
-        assertThat(response).isEqualTo("final answer");
+        assertThat(result.finalAnswer()).isEqualTo("final answer");
         assertThat(historyCaptor.getValue()).hasSize(1);
         assertThat(historyCaptor.getValue().get(0)).isNotInstanceOf(UserMessage.class);
     }


### PR DESCRIPTION
## Summary

This branch introduces a full ReAct (Reason-Act-Observe) architecture on top of the existing Spring AI chat client, adding pre-execution planning, transparent tool call tracing, and dynamic tool registration.

### What changed

- **ReAct loop**: Spring AI's `.toolNames().call()` already runs the internal Reason→Action→Observe loop. This PR adds observability and planning on top without modifying that loop.
- **TaskPlanner**: Independent LLM call (temperature=0.3) that generates a 2–5 step JSON plan before the main chat, injected into the system prompt to guide reasoning. Degrades gracefully on failure.
- **ToolExecutionAspect**: `@Around` AOP advice on `com.dawn.ai.agent.tools.*.apply(..)` — automatically traces every tool invocation (input, output, duration) with zero coupling to tool classes.
- **StepCollector**: ThreadLocal-based request-scoped collector bridging AOP and Orchestrator. Lifecycle managed via `init() → record() → collect() → clear()` in a `try/finally` block.
- **ToolRegistry**: Auto-discovers all Tool beans under `com.dawn.ai.agent.tools` at startup via `@Description` annotation scanning. Eliminates hardcoded `toolNames()` and tool description maps — new tools are picked up automatically.
- **AgentResult / AgentStep / PlanStep**: Structured data models replacing the bare `String` return from AgentOrchestrator.
- **ChatResponse**: Extended with `steps`, `planSummary`, `totalSteps` fields.
- **Config**: `app.ai.react.{max-steps, show-steps, plan-enabled}` toggles added.

### New files

| File | Role |
|---|---|
| `AgentOrchestrator.java` | Orchestrates full ReAct flow per request |
| `TaskPlanner.java` | Pre-execution LLM planning call |
| `ToolRegistry.java` | Auto-discovers and registers Tool beans |
| `ToolExecutionAspect.java` | AOP tracing of every tool invocation |
| `StepCollector.java` | ThreadLocal step accumulator |
| `AgentResult / AgentStep / PlanStep` | Structured response models |
| `CLAUDE.md` | Repo guidance for Claude Code |
| `docs/action-plan-2026-03-20.md` | Next action plan (10 issues filed) |

## Test plan

- [x] `POST /api/v1/chat` with weather query → response includes `planSummary` and correct `totalSteps`
- [x] `POST /api/v1/chat` with calculator query → `calculatorTool` step recorded in AOP
- [x] Set `app.ai.react.show-steps=true` → response body includes full `steps` array with `toolName`, `input`, `output`, `durationMs`
- [x] Set `app.ai.react.plan-enabled=false` → Planner skipped, response still works
- [ ] Add a new `@Component` + `@Description` Tool bean → startup log shows it auto-registered, no Orchestrator changes needed
- [x] `GET /actuator/prometheus` → `ai.agent.chat.duration` metric visible