### PR TITLE
feat(agent): add structured planning output and logging safeguards

### DIFF
--- a/docs/react-design.md
+++ b/docs/react-design.md
@@ -71,13 +71,16 @@ public record AgentStep(
 ```java
 package com.dawn.ai.agent;
 
+import com.dawn.ai.agent.plan.PlanStep;
+
 import java.util.List;
 
 public record AgentResult(
         String finalAnswer,
         List<AgentStep> steps,
         List<PlanStep> plan
-) {}
+) {
+}
 ```
 
 ### 3. `agent/PlanStep.java`

--- a/src/main/java/com/dawn/ai/agent/AgentOrchestrator.java
+++ b/src/main/java/com/dawn/ai/agent/AgentOrchestrator.java
@@ -12,12 +12,13 @@ import org.springframework.ai.chat.messages.AssistantMessage;
 import org.springframework.ai.chat.messages.Message;
 import org.springframework.ai.chat.messages.UserMessage;
 import org.springframework.ai.chat.model.ChatResponse;
-
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
-import java.util.*;
-import java.util.stream.Collectors;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
 
 /**
  * Agent Orchestrator — orchestrates the full ReAct loop with planning and step tracing.
@@ -29,9 +30,8 @@ import java.util.stream.Collectors;
  *  4. chatClient + .toolNames()    — Spring AI handles the tool-calling loop
  *  5. ToolExecutionAspect (AOP)    — intercepts each tool call, records it automatically
  *  6. StepCollector.collect()      — gather all recorded steps
- *  7. Mark plan steps completed    — correlate plan with actual tool calls
- *  8. Persist to memory            — save turn to Redis
- *  9. StepCollector.clear()        — prevent ThreadLocal memory leak
+ *  7. Persist to memory            — save turn to Redis
+ *  8. StepCollector.clear()        — prevent ThreadLocal memory leak
  */
 @Slf4j
 @Service
@@ -74,26 +74,18 @@ public class AgentOrchestrator {
     }
 
     private AgentResult doChat(String sessionId, String userMessage) {
-        // ① Reset per-request step tracking
         StepCollector.init();
         try {
-            // ② Optional pre-execution planning
-            List<PlanStep> plan;
-            if (planEnabled) {
-                plan = taskPlanner.plan(userMessage, toolRegistry.getDescriptions());
-            } else {
-                plan = Collections.emptyList();
-            }
+            List<PlanStep> plan = planEnabled
+                    ? taskPlanner.plan(userMessage, toolRegistry.getDescriptions())
+                    : Collections.emptyList();
 
-            // ③ Compose system prompt: base + plan summary + max-steps hint
             String systemPrompt = baseSystemPrompt
                     + formatPlan(plan)
                     + String.format("%n请在回复中简短说明每次工具调用的原因。最多调用工具 %d 次。", maxSteps);
 
-            // ④ Load conversation history
             List<Message> history = buildHistory(sessionId);
 
-            // ⑤ LLM call — AOP intercepts tool invocations inside this call
             ChatResponse chatResponse = chatClient.prompt()
                     .system(systemPrompt)
                     .messages(history)
@@ -103,17 +95,10 @@ public class AgentOrchestrator {
                     .chatResponse();
 
             String response = chatResponse.getResult().getOutput().getText();
-
-            // ⑥ Record token usage metrics
             recordTokenUsage(chatResponse);
 
-            // ⑦ Collect the steps recorded by ToolExecutionAspect
             List<AgentStep> steps = StepCollector.collect();
 
-            // ⑧ Mark which plan steps were fulfilled
-            markPlanStepsCompleted(plan, steps);
-
-            // ⑨ Persist turn to memory
             memoryService.addMessage(sessionId, "user", userMessage);
             memoryService.addMessage(sessionId, "assistant", response);
 
@@ -122,16 +107,16 @@ public class AgentOrchestrator {
                     userMessage.substring(0, Math.min(50, userMessage.length())));
 
             return new AgentResult(response, steps, plan);
-
         } finally {
-            // ⑩ Always clean up to prevent ThreadLocal memory leaks
             StepCollector.clear();
         }
     }
 
     private void recordTokenUsage(ChatResponse chatResponse) {
         org.springframework.ai.chat.metadata.Usage usage = chatResponse.getMetadata().getUsage();
-        if (usage == null) return;
+        if (usage == null) {
+            return;
+        }
 
         Integer inputTokens = usage.getPromptTokens();
         Integer outputTokens = usage.getCompletionTokens();
@@ -159,27 +144,16 @@ public class AgentOrchestrator {
         return messages;
     }
 
-    /** Formats the plan into a human-readable block for the system prompt. */
     private String formatPlan(List<PlanStep> plan) {
-        if (plan.isEmpty()) return "";
+        if (plan.isEmpty()) {
+            return "";
+        }
         StringBuilder sb = new StringBuilder("\n\n【执行计划】\n");
         for (PlanStep step : plan) {
-            sb.append(step.getStepNumber())
-              .append(". [").append(step.getAction()).append("] ")
-              .append(step.getReason()).append("\n");
+            sb.append(step.step())
+                    .append(". [").append(step.action()).append("] ")
+                    .append(step.reason()).append("\n");
         }
         return sb.toString();
-    }
-
-    /** Marks plan steps as completed based on which tools were actually invoked. */
-    private void markPlanStepsCompleted(List<PlanStep> plan, List<AgentStep> steps) {
-        Set<String> usedTools = steps.stream()
-                .map(AgentStep::toolName)
-                .collect(Collectors.toSet());
-        for (PlanStep planStep : plan) {
-            if (usedTools.contains(planStep.getAction()) || "finish".equals(planStep.getAction())) {
-                planStep.setCompleted(true);
-            }
-        }
     }
 }

--- a/src/main/java/com/dawn/ai/agent/AgentOrchestrator.java
+++ b/src/main/java/com/dawn/ai/agent/AgentOrchestrator.java
@@ -1,5 +1,7 @@
 package com.dawn.ai.agent;
 
+import com.dawn.ai.agent.plan.PlanStep;
+import com.dawn.ai.agent.plan.TaskPlanner;
 import com.dawn.ai.service.MemoryService;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;

--- a/src/main/java/com/dawn/ai/agent/AgentOrchestrator.java
+++ b/src/main/java/com/dawn/ai/agent/AgentOrchestrator.java
@@ -2,6 +2,7 @@ package com.dawn.ai.agent;
 
 import com.dawn.ai.agent.plan.PlanStep;
 import com.dawn.ai.agent.plan.TaskPlanner;
+import com.dawn.ai.exception.PlanGenerationException;
 import com.dawn.ai.service.MemoryService;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
@@ -78,9 +79,7 @@ public class AgentOrchestrator {
     private AgentResult doChat(String sessionId, String userMessage) {
         StepCollector.init();
         try {
-            List<PlanStep> plan = planEnabled
-                    ? taskPlanner.plan(userMessage, toolRegistry.getDescriptions())
-                    : Collections.emptyList();
+            List<PlanStep> plan = resolvePlan(userMessage);
 
             String systemPrompt = baseSystemPrompt
                     + formatPlan(plan)
@@ -111,6 +110,21 @@ public class AgentOrchestrator {
             return new AgentResult(response, steps, plan);
         } finally {
             StepCollector.clear();
+        }
+    }
+
+    private List<PlanStep> resolvePlan(String userMessage) {
+        if (!planEnabled) {
+            return Collections.emptyList();
+        }
+
+        try {
+            return taskPlanner.plan(userMessage, toolRegistry.getDescriptions());
+        } catch (PlanGenerationException exception) {
+            log.warn("[AgentOrchestrator] Planner failed, falling back to direct execution. userMsg={}, reason={}",
+                    userMessage.substring(0, Math.min(50, userMessage.length())),
+                    exception.getMessage());
+            return Collections.emptyList();
         }
     }
 

--- a/src/main/java/com/dawn/ai/agent/AgentResult.java
+++ b/src/main/java/com/dawn/ai/agent/AgentResult.java
@@ -1,5 +1,7 @@
 package com.dawn.ai.agent;
 
+import com.dawn.ai.agent.plan.PlanStep;
+
 import java.util.List;
 
 /**

--- a/src/main/java/com/dawn/ai/agent/PlanStep.java
+++ b/src/main/java/com/dawn/ai/agent/PlanStep.java
@@ -1,16 +1,23 @@
 package com.dawn.ai.agent;
 
-import lombok.Data;
-
 /**
- * A single step in the pre-execution plan.
- * Uses a regular class (not record) because completed/result are mutated during execution.
+ * A single planner-generated step.
+ * This is intentionally a pure value object so structured output parsing can fail fast.
  */
-@Data
-public class PlanStep {
-    private final int stepNumber;
-    private final String action;   // tool name or "finish" for the last step
-    private final String reason;
-    private boolean completed = false;
-    private String result;
+public record PlanStep(
+        Integer step,
+        String action,
+        String reason
+) {
+    public PlanStep {
+        if (step == null || step < 1) {
+            throw new IllegalArgumentException("step must be a positive integer");
+        }
+        if (action == null || action.isBlank()) {
+            throw new IllegalArgumentException("action must not be blank");
+        }
+        if (reason == null || reason.isBlank()) {
+            throw new IllegalArgumentException("reason must not be blank");
+        }
+    }
 }

--- a/src/main/java/com/dawn/ai/agent/TaskPlanner.java
+++ b/src/main/java/com/dawn/ai/agent/TaskPlanner.java
@@ -61,6 +61,7 @@ public class TaskPlanner {
      * @throws PlanGenerationException when the model output is not valid structured planner output
      */
     public List<PlanStep> plan(String task, Map<String, String> toolDescriptions) {
+        try {
         BeanOutputConverter<List<PlanStep>> converter =
                 new BeanOutputConverter<>(new ParameterizedTypeReference<>() {}, objectMapper);
 
@@ -71,7 +72,7 @@ public class TaskPlanner {
                 .call()
                 .content();
 
-        try {
+
             List<PlanStep> plan = converter.convert(raw);
             validatePlan(plan, toolDescriptions.keySet());
 

--- a/src/main/java/com/dawn/ai/agent/TaskPlanner.java
+++ b/src/main/java/com/dawn/ai/agent/TaskPlanner.java
@@ -1,6 +1,6 @@
 package com.dawn.ai.agent;
 
-import com.fasterxml.jackson.core.type.TypeReference;
+import com.dawn.ai.exception.PlanGenerationException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
@@ -8,24 +8,25 @@ import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.ai.chat.client.ChatClient;
+import org.springframework.ai.converter.BeanOutputConverter;
 import org.springframework.ai.openai.OpenAiChatOptions;
+import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.stereotype.Service;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 /**
  * Generates a structured execution plan before the main ReAct loop.
  *
- * The planning call is completely independent from the conversation history:
+ * The planning call is independent from the conversation history:
  * it needs a low-temperature, global view of the task, not a contextual one.
- * Failure is non-fatal — the orchestrator degrades gracefully to no-plan mode.
  *
  * Metrics:
- *   ai.planner.result{status=success} — plan generated successfully
- *   ai.planner.result{status=fallback} — planning failed, fell back to no-plan
+ *   ai.planner.result{status=success}     — plan generated and validated successfully
+ *   ai.planner.result{status=parse_error} — structured output could not be parsed or validated
  */
 @Slf4j
 @Service
@@ -37,94 +38,93 @@ public class TaskPlanner {
     private final MeterRegistry meterRegistry;
 
     private Counter successCounter;
-    private Counter fallbackCounter;
+    private Counter parseErrorCounter;
 
     @PostConstruct
     void initMetrics() {
         successCounter = Counter.builder("ai.planner.result")
-                .description("TaskPlanner outcomes: success vs fallback")
+                .description("TaskPlanner outcomes: success vs parse_error")
                 .tag("status", "success")
                 .register(meterRegistry);
-        fallbackCounter = Counter.builder("ai.planner.result")
-                .description("TaskPlanner outcomes: success vs fallback")
-                .tag("status", "fallback")
+        parseErrorCounter = Counter.builder("ai.planner.result")
+                .description("TaskPlanner outcomes: success vs parse_error")
+                .tag("status", "parse_error")
                 .register(meterRegistry);
     }
 
     /**
      * Plans the steps required to complete {@code task} given the available tools.
      *
-     * @param task                 the user's request
-     * @param toolDescriptions     map of tool name → description
-     * @return ordered plan steps, or an empty list on any failure
+     * @param task             the user's request
+     * @param toolDescriptions map of tool name → description
+     * @return ordered plan steps
+     * @throws PlanGenerationException when the model output is not valid structured planner output
      */
     public List<PlanStep> plan(String task, Map<String, String> toolDescriptions) {
-        String prompt = buildPlanPrompt(task, toolDescriptions);
+        BeanOutputConverter<List<PlanStep>> converter =
+                new BeanOutputConverter<>(new ParameterizedTypeReference<>() {}, objectMapper);
+
+        String prompt = buildPlanPrompt(task, toolDescriptions, converter.getFormat());
+        String raw = chatClient.prompt()
+                .user(prompt)
+                .options(OpenAiChatOptions.builder().temperature(0.3).build())
+                .call()
+                .content();
+
         try {
-            String raw = chatClient.prompt()
-                    .user(prompt)
-                    .options(OpenAiChatOptions.builder().temperature(0.3).build())
-                    .call()
-                    .content();
-
-            String json = extractJson(raw);
-            List<Map<String, Object>> rawSteps = objectMapper.readValue(
-                    json, new TypeReference<List<Map<String, Object>>>() {});
-
-            List<PlanStep> plan = rawSteps.stream()
-                    .map(m -> new PlanStep(
-                            ((Number) m.get("step")).intValue(),
-                            String.valueOf(m.get("action")),
-                            String.valueOf(m.get("reason"))))
-                    .collect(Collectors.toList());
+            List<PlanStep> plan = converter.convert(raw);
+            validatePlan(plan, toolDescriptions.keySet());
 
             log.debug("[TaskPlanner] Generated {} steps for task: {}", plan.size(),
                     task.substring(0, Math.min(50, task.length())));
             successCounter.increment();
             return plan;
-
-        } catch (Exception e) {
-            log.warn("[TaskPlanner] Planning failed, falling back to no-plan mode: {}", e.getMessage());
-            fallbackCounter.increment();
-            return Collections.emptyList();
+        } catch (PlanGenerationException exception) {
+            parseErrorCounter.increment();
+            throw exception;
+        } catch (RuntimeException exception) {
+            parseErrorCounter.increment();
+            throw new PlanGenerationException("Planner returned invalid structured output.", exception);
         }
     }
 
-    private String buildPlanPrompt(String task, Map<String, String> toolDescriptions) {
+    private String buildPlanPrompt(String task,
+                                   Map<String, String> toolDescriptions,
+                                   String formatInstructions) {
         String toolList = toolDescriptions.entrySet().stream()
                 .map(e -> "- " + e.getKey() + ": " + e.getValue())
                 .collect(Collectors.joining("\n"));
 
         return """
-                你是一个任务规划助手。请分析用户的任务，生成一个 2-5 步的执行计划。
-                
+                你是一个任务规划助手。请分析用户的任务，并生成一个 2-5 步的执行计划。
+
                 可用工具：
                 %s
-                
-                严格以 JSON 数组格式返回，每项包含：
-                - step: 步骤编号（从 1 开始）
-                - action: 工具名称（从上方可用工具中选择），最后一步固定为 "finish"
-                - reason: 使用该工具的原因（中文，简短）
-                
-                要求：
-                - 只返回 JSON 数组，不要其他文字
-                - 最后一步必须是 {"step": N, "action": "finish", "reason": "完成任务"}
-                
+
+                业务约束：
+                - action 只能从上方可用工具中选择，最后一步固定为 "finish"
+                - reason 使用中文，简短说明为什么要执行该步骤
+
                 用户任务：%s
-                
-                示例格式：
-                [{"step":1,"action":"weatherTool","reason":"查询北京当前天气"},{"step":2,"action":"finish","reason":"完成任务"}]
-                """.formatted(toolList, task);
+
+                %s
+                """.formatted(toolList, task, formatInstructions);
     }
 
-    /** Extracts the JSON array from LLM output that may contain markdown fences. */
-    private String extractJson(String raw) {
-        String trimmed = raw.trim();
-        int start = trimmed.indexOf('[');
-        int end = trimmed.lastIndexOf(']');
-        if (start >= 0 && end > start) {
-            return trimmed.substring(start, end + 1);
+    private void validatePlan(List<PlanStep> plan, Set<String> toolNames) {
+        if (plan == null || plan.isEmpty()) {
+            throw new PlanGenerationException("Planner returned an empty plan.");
         }
-        return trimmed;
+
+        for (PlanStep step : plan) {
+            if (!"finish".equals(step.action()) && !toolNames.contains(step.action())) {
+                throw new PlanGenerationException("Planner returned an unknown tool action: " + step.action());
+            }
+        }
+
+        PlanStep lastStep = plan.get(plan.size() - 1);
+        if (!"finish".equals(lastStep.action())) {
+            throw new PlanGenerationException("Planner plan must end with finish.");
+        }
     }
 }

--- a/src/main/java/com/dawn/ai/agent/plan/PlanStep.java
+++ b/src/main/java/com/dawn/ai/agent/plan/PlanStep.java
@@ -1,0 +1,23 @@
+package com.dawn.ai.agent.plan;
+
+/**
+ * A single planner-generated step.
+ * This is intentionally a pure value object so structured output parsing can fail fast.
+ */
+public record PlanStep(
+        Integer step,
+        String action,
+        String reason
+) {
+    public PlanStep {
+        if (step == null || step < 1) {
+            throw new IllegalArgumentException("step must be a positive integer");
+        }
+        if (action == null || action.isBlank()) {
+            throw new IllegalArgumentException("action must not be blank");
+        }
+        if (reason == null || reason.isBlank()) {
+            throw new IllegalArgumentException("reason must not be blank");
+        }
+    }
+}

--- a/src/main/java/com/dawn/ai/agent/plan/TaskPlanner.java
+++ b/src/main/java/com/dawn/ai/agent/plan/TaskPlanner.java
@@ -1,0 +1,130 @@
+package com.dawn.ai.agent.plan;
+
+import com.dawn.ai.exception.PlanGenerationException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.ai.chat.client.ChatClient;
+import org.springframework.ai.converter.BeanOutputConverter;
+import org.springframework.ai.openai.OpenAiChatOptions;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * Generates a structured execution plan before the main ReAct loop.
+ *
+ * The planning call is independent from the conversation history:
+ * it needs a low-temperature, global view of the task, not a contextual one.
+ *
+ * Metrics:
+ *   ai.planner.result{status=success}     — plan generated and validated successfully
+ *   ai.planner.result{status=parse_error} — structured output could not be parsed or validated
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class TaskPlanner {
+
+    private final ChatClient chatClient;
+    private final ObjectMapper objectMapper;
+    private final MeterRegistry meterRegistry;
+
+    private Counter successCounter;
+    private Counter parseErrorCounter;
+
+    @PostConstruct
+    public void initMetrics() {
+        successCounter = Counter.builder("ai.planner.result")
+                .description("TaskPlanner outcomes: success vs parse_error")
+                .tag("status", "success")
+                .register(meterRegistry);
+        parseErrorCounter = Counter.builder("ai.planner.result")
+                .description("TaskPlanner outcomes: success vs parse_error")
+                .tag("status", "parse_error")
+                .register(meterRegistry);
+    }
+
+    /**
+     * Plans the steps required to complete {@code task} given the available tools.
+     *
+     * @param task             the user's request
+     * @param toolDescriptions map of tool name → description
+     * @return ordered plan steps
+     * @throws PlanGenerationException when the model output is not valid structured planner output
+     */
+    public List<PlanStep> plan(String task, Map<String, String> toolDescriptions) {
+        BeanOutputConverter<List<PlanStep>> converter =
+                new BeanOutputConverter<>(new ParameterizedTypeReference<>() {}, objectMapper);
+
+        String prompt = buildPlanPrompt(task, toolDescriptions, converter.getFormat());
+        String raw = chatClient.prompt()
+                .user(prompt)
+                .options(OpenAiChatOptions.builder().temperature(0.3).build())
+                .call()
+                .content();
+
+        try {
+            List<PlanStep> plan = converter.convert(raw);
+            validatePlan(plan, toolDescriptions.keySet());
+
+            log.debug("[TaskPlanner] Generated {} steps for task: {}", plan.size(),
+                    task.substring(0, Math.min(50, task.length())));
+            successCounter.increment();
+            return plan;
+        } catch (PlanGenerationException exception) {
+            parseErrorCounter.increment();
+            throw exception;
+        } catch (RuntimeException exception) {
+            parseErrorCounter.increment();
+            throw new PlanGenerationException("Planner returned invalid structured output.", exception);
+        }
+    }
+
+    private String buildPlanPrompt(String task,
+                                   Map<String, String> toolDescriptions,
+                                   String formatInstructions) {
+        String toolList = toolDescriptions.entrySet().stream()
+                .map(e -> "- " + e.getKey() + ": " + e.getValue())
+                .collect(Collectors.joining("\n"));
+
+        return """
+                你是一个任务规划助手。请分析用户的任务，并生成一个 2-5 步的执行计划。
+
+                可用工具：
+                %s
+
+                业务约束：
+                - action 只能从上方可用工具中选择，最后一步固定为 "finish"
+                - reason 使用中文，简短说明为什么要执行该步骤
+
+                用户任务：%s
+
+                %s
+                """.formatted(toolList, task, formatInstructions);
+    }
+
+    private void validatePlan(List<PlanStep> plan, Set<String> toolNames) {
+        if (plan == null || plan.isEmpty()) {
+            throw new PlanGenerationException("Planner returned an empty plan.");
+        }
+
+        for (PlanStep step : plan) {
+            if (!"finish".equals(step.action()) && !toolNames.contains(step.action())) {
+                throw new PlanGenerationException("Planner returned an unknown tool action: " + step.action());
+            }
+        }
+
+        PlanStep lastStep = plan.get(plan.size() - 1);
+        if (!"finish".equals(lastStep.action())) {
+            throw new PlanGenerationException("Planner plan must end with finish.");
+        }
+    }
+}

--- a/src/main/java/com/dawn/ai/config/AiConfig.java
+++ b/src/main/java/com/dawn/ai/config/AiConfig.java
@@ -8,13 +8,25 @@ import org.springframework.ai.chat.client.ChatClient;
 import org.springframework.ai.chat.model.ChatModel;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.ApplicationRunner;
+import org.springframework.context.annotation.Primary;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.client.ClientHttpRequestInterceptor;
+import org.springframework.http.client.BufferingClientHttpRequestFactory;
+import org.springframework.http.client.ClientHttpResponse;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
+import org.springframework.util.StreamUtils;
+import org.springframework.web.client.RestClient;
+
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 
 @Configuration
 public class AiConfig {
 
     private static final Logger log = LoggerFactory.getLogger(AiConfig.class);
+    private static final int MAX_LOG_BODY_LENGTH = 4000;
 
     @Value("${app.ai.system-prompt:You are a helpful AI assistant.}")
     private String defaultSystemPrompt;
@@ -30,6 +42,33 @@ public class AiConfig {
         return ChatClient.builder(chatModel)
                 .defaultSystem(defaultSystemPrompt)
                 .build();
+    }
+
+    @Bean
+    @Primary
+    public RestClient.Builder openAiRestClientBuilder() {
+        ClientHttpRequestInterceptor loggingInterceptor = (request, body, execution) -> {
+            log.info("[AI HTTP] {} {}", request.getMethod(), request.getURI());
+            log.info("[AI HTTP] Request headers={}", sanitizeHeaders(request.getHeaders()));
+            log.info("[AI HTTP] Request body={}", abbreviate(new String(body, StandardCharsets.UTF_8)));
+            ClientHttpResponse response = execution.execute(request, body);
+
+            byte[] responseBody = StreamUtils.copyToByteArray(response.getBody());
+            Charset responseCharset = resolveCharset(response.getHeaders());
+            String responseBodyText = new String(responseBody, responseCharset);
+
+            log.info("[AI HTTP] Response status={} contentType={} contentLength={}",
+                    response.getStatusCode(),
+                    response.getHeaders().getContentType(),
+                    responseBody.length);
+            log.info("[AI HTTP] Response body={}", abbreviate(responseBodyText));
+
+            return response;
+        };
+
+        return RestClient.builder()
+                .requestFactory(new BufferingClientHttpRequestFactory(new SimpleClientHttpRequestFactory()))
+                .requestInterceptor(loggingInterceptor);
     }
 
     @Bean
@@ -61,5 +100,45 @@ public class AiConfig {
         }
         return apiKey.substring(0, 4) + "..." + apiKey.substring(apiKey.length() - 4)
                 + " (len=" + apiKey.length() + ")";
+    }
+
+    private Charset resolveCharset(HttpHeaders headers) {
+        if (headers.getContentType() != null && headers.getContentType().getCharset() != null) {
+            return headers.getContentType().getCharset();
+        }
+        return StandardCharsets.UTF_8;
+    }
+
+    private String abbreviate(String value) {
+        if (value == null || value.length() <= MAX_LOG_BODY_LENGTH) {
+            return value;
+        }
+        return value.substring(0, MAX_LOG_BODY_LENGTH) + "...(truncated)";
+    }
+
+    private HttpHeaders sanitizeHeaders(HttpHeaders headers) {
+        HttpHeaders sanitized = new HttpHeaders();
+        headers.forEach((name, values) -> {
+            if (HttpHeaders.AUTHORIZATION.equalsIgnoreCase(name)) {
+                sanitized.add(name, maskAuthorization(values.isEmpty() ? "" : values.get(0)));
+                return;
+            }
+            sanitized.put(name, values);
+        });
+        return sanitized;
+    }
+
+    private String maskAuthorization(String authorization) {
+        if (authorization == null || authorization.isBlank()) {
+            return "<empty>";
+        }
+
+        int separatorIndex = authorization.indexOf(' ');
+        if (separatorIndex < 0 || separatorIndex == authorization.length() - 1) {
+            return "***";
+        }
+
+        return authorization.substring(0, separatorIndex + 1)
+                + maskApiKey(authorization.substring(separatorIndex + 1));
     }
 }

--- a/src/main/java/com/dawn/ai/exception/ApiExceptionHandler.java
+++ b/src/main/java/com/dawn/ai/exception/ApiExceptionHandler.java
@@ -60,6 +60,14 @@ public class ApiExceptionHandler {
         return buildResponse(HttpStatus.BAD_REQUEST, exception.getMessage(), request.getRequestURI());
     }
 
+    @ExceptionHandler(PlanGenerationException.class)
+    public ResponseEntity<Map<String, Object>> handlePlanGeneration(
+            PlanGenerationException exception,
+            HttpServletRequest request) {
+        recordError("plan_generation_error");
+        return buildResponse(HttpStatus.BAD_GATEWAY, exception.getMessage(), request.getRequestURI());
+    }
+
     @ExceptionHandler(Exception.class)
     public ResponseEntity<Map<String, Object>> handleUnexpected(
             Exception exception,

--- a/src/main/java/com/dawn/ai/exception/PlanGenerationException.java
+++ b/src/main/java/com/dawn/ai/exception/PlanGenerationException.java
@@ -1,0 +1,12 @@
+package com.dawn.ai.exception;
+
+public class PlanGenerationException extends RuntimeException {
+
+    public PlanGenerationException(String message) {
+        super(message);
+    }
+
+    public PlanGenerationException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/com/dawn/ai/service/ChatService.java
+++ b/src/main/java/com/dawn/ai/service/ChatService.java
@@ -77,7 +77,7 @@ public class ChatService {
     private String formatPlanSummary(List<PlanStep> plan) {
         if (plan == null || plan.isEmpty()) return "";
         return plan.stream()
-                .map(s -> "步骤" + s.getStepNumber() + ": " + s.getAction())
+                .map(s -> "步骤" + s.step() + ": " + s.action())
                 .collect(Collectors.joining(" → "));
     }
 }

--- a/src/main/java/com/dawn/ai/service/ChatService.java
+++ b/src/main/java/com/dawn/ai/service/ChatService.java
@@ -2,7 +2,7 @@ package com.dawn.ai.service;
 
 import com.dawn.ai.agent.AgentResult;
 import com.dawn.ai.agent.AgentOrchestrator;
-import com.dawn.ai.agent.PlanStep;
+import com.dawn.ai.agent.plan.PlanStep;
 import com.dawn.ai.config.AiAvailabilityChecker;
 import com.dawn.ai.dto.ChatRequest;
 import com.dawn.ai.dto.ChatResponse;

--- a/src/test/java/com/dawn/ai/agent/AgentOrchestratorTest.java
+++ b/src/test/java/com/dawn/ai/agent/AgentOrchestratorTest.java
@@ -1,6 +1,7 @@
 package com.dawn.ai.agent;
 
 import com.dawn.ai.agent.plan.TaskPlanner;
+import com.dawn.ai.exception.PlanGenerationException;
 import com.dawn.ai.service.MemoryService;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.junit.jupiter.api.BeforeEach;
@@ -22,6 +23,7 @@ import java.util.Map;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -84,5 +86,31 @@ class AgentOrchestratorTest {
         assertThat(result.finalAnswer()).isEqualTo("final answer");
         assertThat(historyCaptor.getValue()).hasSize(1);
         assertThat(historyCaptor.getValue().get(0)).isNotInstanceOf(UserMessage.class);
+    }
+
+    @Test
+    void shouldFallbackWhenPlannerGenerationFails() {
+        ChatResponse chatResponse = new ChatResponse(
+                List.of(new Generation(new AssistantMessage("final answer")))
+        );
+
+        when(taskPlanner.plan(anyString(), any()))
+                .thenThrow(new PlanGenerationException("Planner returned invalid structured output."));
+        when(memoryService.getHistory("session-2")).thenReturn(Collections.emptyList());
+        when(chatClient.prompt()).thenReturn(requestSpec);
+        when(requestSpec.system(anyString())).thenReturn(requestSpec);
+        when(requestSpec.messages(any(List.class))).thenReturn(requestSpec);
+        when(requestSpec.user(anyString())).thenReturn(requestSpec);
+        when(requestSpec.toolNames(any(String[].class))).thenReturn(requestSpec);
+        when(requestSpec.call()).thenReturn(callResponseSpec);
+        when(callResponseSpec.chatResponse()).thenReturn(chatResponse);
+
+        AgentResult result = agentOrchestrator.chat("session-2", "current question");
+
+        assertThat(result.finalAnswer()).isEqualTo("final answer");
+        assertThat(result.plan()).isEmpty();
+        verify(chatClient).prompt();
+        verify(requestSpec, never()).system(org.mockito.ArgumentMatchers.contains("【执行计划】"));
+        verify(memoryService).addMessage("session-2", "assistant", "final answer");
     }
 }

--- a/src/test/java/com/dawn/ai/agent/AgentOrchestratorTest.java
+++ b/src/test/java/com/dawn/ai/agent/AgentOrchestratorTest.java
@@ -1,5 +1,6 @@
 package com.dawn.ai.agent;
 
+import com.dawn.ai.agent.plan.TaskPlanner;
 import com.dawn.ai.service.MemoryService;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.junit.jupiter.api.BeforeEach;

--- a/src/test/java/com/dawn/ai/agent/TaskPlannerTest.java
+++ b/src/test/java/com/dawn/ai/agent/TaskPlannerTest.java
@@ -1,0 +1,85 @@
+package com.dawn.ai.agent;
+
+import com.dawn.ai.exception.PlanGenerationException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.ai.chat.client.ChatClient;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class TaskPlannerTest {
+
+    private TaskPlanner taskPlanner;
+
+    @Mock private ChatClient chatClient;
+    @Mock private ChatClient.ChatClientRequestSpec requestSpec;
+    @Mock private ChatClient.CallResponseSpec callResponseSpec;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+
+        when(chatClient.prompt()).thenReturn(requestSpec);
+        when(requestSpec.user(any(String.class))).thenReturn(requestSpec);
+        when(requestSpec.options(any())).thenReturn(requestSpec);
+        when(requestSpec.call()).thenReturn(callResponseSpec);
+
+        taskPlanner = new TaskPlanner(chatClient, new ObjectMapper(), new SimpleMeterRegistry());
+        taskPlanner.initMetrics();
+    }
+
+    @Test
+    void shouldParsePlanWithBeanOutputConverter() {
+        when(callResponseSpec.content()).thenReturn("""
+                [
+                  {"step": 1, "action": "weatherTool", "reason": "先查询天气"},
+                  {"step": 2, "action": "finish", "reason": "完成任务"}
+                ]
+                """);
+
+        var plan = taskPlanner.plan("帮我看天气", Map.of("weatherTool", "查询天气"));
+
+        assertThat(plan).hasSize(2);
+        assertThat(plan.get(0).step()).isEqualTo(1);
+        assertThat(plan.get(0).action()).isEqualTo("weatherTool");
+        assertThat(plan.get(1).action()).isEqualTo("finish");
+
+        ArgumentCaptor<String> promptCaptor = ArgumentCaptor.forClass(String.class);
+        verify(requestSpec).user(promptCaptor.capture());
+        assertThat(promptCaptor.getValue()).doesNotContain("严格以 JSON 数组格式返回");
+    }
+
+    @Test
+    void shouldThrowWhenPlannerOutputIsNotStructuredJson() {
+        when(callResponseSpec.content()).thenReturn("我建议先查天气，再完成任务。");
+
+        assertThatThrownBy(() -> taskPlanner.plan("帮我看天气", Map.of("weatherTool", "查询天气")))
+                .isInstanceOf(PlanGenerationException.class)
+                .hasMessage("Planner returned invalid structured output.");
+    }
+
+    @Test
+    void shouldThrowWhenRequiredPlanFieldIsMissing() {
+        when(callResponseSpec.content()).thenReturn("""
+                [
+                  {"action": "weatherTool", "reason": "先查询天气"},
+                  {"step": 2, "action": "finish", "reason": "完成任务"}
+                ]
+                """);
+
+        assertThatThrownBy(() -> taskPlanner.plan("帮我看天气", Map.of("weatherTool", "查询天气")))
+                .isInstanceOf(PlanGenerationException.class)
+                .hasMessage("Planner returned invalid structured output.");
+    }
+}

--- a/src/test/java/com/dawn/ai/agent/TaskPlannerTest.java
+++ b/src/test/java/com/dawn/ai/agent/TaskPlannerTest.java
@@ -1,5 +1,6 @@
 package com.dawn.ai.agent;
 
+import com.dawn.ai.agent.plan.TaskPlanner;
 import com.dawn.ai.exception.PlanGenerationException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;


### PR DESCRIPTION
Add structured planning output, request and response logging, and graceful fallback behavior around task planning in the agent flow. The change also extracts planning into a dedicated package, adds configuration wiring, updates the API error surface, and includes focused planner and orchestrator tests.

These changes are meant to make the agent path both more observable and more resilient. Planning is useful for better step quality, but it should not prevent the main chat flow from completing, so this PR treats planning as an enhancement instead of a hard dependency while also improving visibility into request and response behavior.

I considered keeping the previous planner implementation inline and relying on prompt constraints alone, but that would keep planning concerns mixed into the orchestration path and make failures harder to reason about. Separating the planner types and fallback path makes the flow easier to evolve and safer when the planning call is unstable.

The most important review areas are the fallback path in `AgentOrchestrator`, the new classes under `src/main/java/com/dawn/ai/agent/plan/`, and the configuration and exception handling changes that connect planner failures back to the API layer. `docs/react-design.md` was updated to keep the design notes aligned with the new structure.