### PR TITLE
feat: RAG Sparse Retrevial支持regconfig配置化

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,8 +8,8 @@ COPY pom.xml .
 COPY .mvn/ .mvn/
 
 COPY src/ src/
-RUN mvn clean package -DskipTests -q
-# RUN mvn -s .mvn/settings.xml clean package -DskipTests -q
+# RUN mvn clean package -DskipTests -q
+RUN mvn -s .mvn/settings.xml clean package -DskipTests
 
 # ---- Runtime Stage ----
 FROM eclipse-temurin:17-jre-alpine

--- a/docs/.obsidian/workspace.json
+++ b/docs/.obsidian/workspace.json
@@ -4,56 +4,25 @@
     "type": "split",
     "children": [
       {
-        "id": "e732d2c3844a9913",
+        "id": "b69c90f73be88802",
         "type": "tabs",
         "children": [
           {
-            "id": "cbdf16327c09261d",
+            "id": "8df6304ac225832a",
             "type": "leaf",
             "state": {
               "type": "markdown",
               "state": {
-                "file": "SSE/code-review-todo-2026-04-22.md",
+                "file": "RAG/postgres-text-search-configs-2026-04-25.md",
                 "mode": "source",
                 "source": false,
                 "backlinks": false
               },
               "icon": "lucide-file",
-              "title": "code-review-todo-2026-04-22"
-            }
-          },
-          {
-            "id": "1e9dfe98c1a773b1",
-            "type": "leaf",
-            "state": {
-              "type": "markdown",
-              "state": {
-                "file": "SSE/TODO.md",
-                "mode": "source",
-                "source": false,
-                "backlinks": false
-              },
-              "icon": "lucide-file",
-              "title": "TODO"
-            }
-          },
-          {
-            "id": "4423da7a07c09c84",
-            "type": "leaf",
-            "state": {
-              "type": "markdown",
-              "state": {
-                "file": "SSE/sse-streaming-solution-2026-04-15.md",
-                "mode": "source",
-                "source": false,
-                "backlinks": false
-              },
-              "icon": "lucide-file",
-              "title": "sse-streaming-solution-2026-04-15"
+              "title": "postgres-text-search-configs-2026-04-25"
             }
           }
-        ],
-        "currentTab": 1
+        ]
       }
     ],
     "direction": "vertical"
@@ -126,7 +95,7 @@
             "state": {
               "type": "backlink",
               "state": {
-                "file": "SSE/TODO.md",
+                "file": "SSE/code-review-todo-2026-04-22.md",
                 "collapseAll": false,
                 "extraContext": false,
                 "sortOrder": "alphabetical",
@@ -136,7 +105,7 @@
                 "unlinkedCollapsed": true
               },
               "icon": "links-coming-in",
-              "title": "TODO 的反向链接列表"
+              "title": "code-review-todo-2026-04-22 的反向链接列表"
             }
           },
           {
@@ -145,12 +114,12 @@
             "state": {
               "type": "outgoing-link",
               "state": {
-                "file": "SSE/TODO.md",
+                "file": "SSE/code-review-todo-2026-04-22.md",
                 "linksCollapsed": false,
                 "unlinkedCollapsed": true
               },
               "icon": "links-going-out",
-              "title": "TODO 的出链列表"
+              "title": "code-review-todo-2026-04-22 的出链列表"
             }
           },
           {
@@ -188,13 +157,13 @@
             "state": {
               "type": "outline",
               "state": {
-                "file": "SSE/TODO.md",
+                "file": "RAG/postgres-text-search-configs-2026-04-25.md",
                 "followCursor": false,
                 "showSearch": false,
                 "searchQuery": ""
               },
               "icon": "lucide-list",
-              "title": "TODO 的大纲"
+              "title": "postgres-text-search-configs-2026-04-25 的大纲"
             }
           }
         ],
@@ -218,9 +187,25 @@
       "obsidian-shellcommands:Shell commands: Custom variables": false
     }
   },
-  "active": "1e9dfe98c1a773b1",
+  "active": "8df6304ac225832a",
   "lastOpenFiles": [
+    "RAG/postgres-text-search-configs-2026-04-25.md",
+    "SSE/sse-streaming-solution-2026-04-15.md",
+    "SSE/TODO.md",
     "SSE/code-review-todo-2026-04-22.md",
-    "SSE/sse-streaming-solution-2026-04-15.md"
+    "notes/spring-ai-react.excalidraw",
+    "notes/spring-ai-notes-2026-03-19.md",
+    "notes/interview-ai-agent-2026-03-09.md",
+    "notes",
+    "memory/agent-memory-architecture-2026-03-10.md",
+    "memory",
+    "grafana/grafana-setup-guide.md",
+    "grafana/grafana-dashboard-customization.md",
+    "grafana",
+    "SSE/thread-model-context-propagation.svg",
+    "ReAct/react-design.md",
+    "ReAct/react-comparison.html",
+    "ReAct/ReAct-SpringAI.png",
+    "ReAct"
   ]
 }

--- a/docs/RAG/postgres-text-search-configs-2026-04-25.md
+++ b/docs/RAG/postgres-text-search-configs-2026-04-25.md
@@ -1,0 +1,282 @@
+# RAG 稀疏检索的 PostgreSQL 文本搜索配置说明
+
+## 背景
+
+本项目的稀疏检索路径并没有使用 pgvector 自带的分词或词干化能力。
+它实际依赖的是 PostgreSQL Full Text Search，也就是 `to_tsvector(...)` 和 `websearch_to_tsquery(...)`。
+
+对应实现见 [src/main/java/com/dawn/ai/rag/retrieval/sparse/PostgresBm25Retriever.java](src/main/java/com/dawn/ai/rag/retrieval/sparse/PostgresBm25Retriever.java)。
+
+这个区分很重要：
+
+- pgvector 负责向量相似度检索
+- PostgreSQL FTS 负责稀疏词法检索
+- `simple`、`english`、`french`、`german` 这些都不是 pgvector 的配置，而是 PostgreSQL 文本搜索配置
+
+## 本次问题的根因
+
+线上现象是：
+
+- query 为 `customer`
+- dense retrieval 命中 2 条
+- sparse retrieval 命中 0 条
+
+进一步排查后发现，库里的文本实际包含的是 `customers`，不是 `customer`。
+
+在 PostgreSQL `simple` 配置下：
+
+- `customer` 会保留为 `customer`
+- `customers` 会保留为 `customers`
+- 二者不会归一成同一个 lexeme
+
+在 PostgreSQL `english` 配置下：
+
+- `customer` 会被词干化为 `custom`
+- `customers` 也会被词干化为 `custom`
+- 因此 sparse 检索可以命中复数形式的文档
+
+数据库侧验证：
+
+```sql
+SELECT ts_debug('simple', 'customer customers returned returning');
+SELECT ts_debug('english', 'customer customers returned returning');
+```
+
+观察结果：
+
+- `simple` 会保留 `customer`、`customers`、`returned`、`returning` 这些不同形式
+- `english` 会把它们归一成 `custom`、`custom`、`return`、`return`
+
+再结合当前 `vector_store` 实例验证：
+
+```sql
+SELECT COUNT(*)
+FROM vector_store
+WHERE to_tsvector('simple', content) @@ websearch_to_tsquery('simple', 'customer');
+```
+
+结果：`0`
+
+```sql
+SELECT COUNT(*)
+FROM vector_store
+WHERE to_tsvector('english', content) @@ websearch_to_tsquery('english', 'customer');
+```
+
+结果：`2`
+
+所以这次 miss 不是并发问题，也不是路由问题，而是 `simple` 不做英文词形归一。
+
+## 当前数据库可用的内建配置
+
+查询方式：
+
+```sql
+SELECT cfgname FROM pg_catalog.pg_ts_config ORDER BY cfgname;
+```
+
+当前实例可用配置包括：
+
+- `arabic`
+- `armenian`
+- `basque`
+- `catalan`
+- `danish`
+- `dutch`
+- `english`
+- `finnish`
+- `french`
+- `german`
+- `greek`
+- `hindi`
+- `hungarian`
+- `indonesian`
+- `irish`
+- `italian`
+- `lithuanian`
+- `nepali`
+- `norwegian`
+- `portuguese`
+- `romanian`
+- `russian`
+- `serbian`
+- `simple`
+- `spanish`
+- `swedish`
+- `tamil`
+- `turkish`
+- `yiddish`
+
+这些配置本质上是 PostgreSQL 预定义好的文本搜索配置对象，由以下几部分组成：
+
+- parser
+- dictionary 列表
+- 针对不同 token 类型的 mapping 规则
+
+## 除了 `simple` 之外，还有哪些能力
+
+### `simple`
+
+特点：
+
+- 只做小写归一
+- 可选停用词过滤
+- 不做 stemming
+- 不做 lemmatization
+
+优点：
+
+- 行为稳定，接近精确词项匹配
+- 适合 SKU、订单号、版本号、术语代码等场景
+- 对混合语言和技术文本比较保守
+
+缺点：
+
+- 单复数不合并
+- 时态变化不合并
+- 对自然语言英文检索召回偏弱
+
+### `english` 及其他语言配置
+
+例如：`english`、`french`、`german`、`spanish`。
+
+特点：
+
+- 带语言相关停用词处理
+- 带词干化能力
+- 会把派生词归一成相同 lexeme
+
+优点：
+
+- 对自然语言问句召回明显更好
+- 英文单复数、时态变化、派生形式更容易命中
+- 适合作为 support 文档、FAQ、政策说明这类英文语料的 sparse 检索基础
+
+缺点：
+
+- 可能对专有名词过度词干化
+- 对混合语言语料不一定合适
+- 某些业务关键词可能被当成停用词或被过度归一
+
+### 自定义配置
+
+PostgreSQL 还支持创建自定义文本搜索配置，而不必只能在 `simple` 和 `english` 之间二选一。
+
+常见能力包括：
+
+- `simple` dictionary：做基础 lower-case 和停用词过滤
+- `snowball` dictionary：做 stemming，例如 `english_stem`
+- `ispell` dictionary：做更丰富的词形归一
+- `synonym` dictionary：把多个术语归一到一个词项
+- `thesaurus` dictionary：支持短语级归一与扩展
+- `unaccent` 过滤字典：先去除重音，再交给后续词典处理
+
+这意味着我们可以构建更贴近业务的配置，例如：
+
+- 先做 `unaccent`
+- 再做业务同义词映射
+- 最后再用 `english_stem` 做兜底词干化
+
+## 本项目的选型建议
+
+### 什么时候用 `english`
+
+如果语料和查询主要是英文自然语言，`english` 更合适。比如：
+
+- refund policy
+- customer order tracking
+- shipping updates
+- return eligibility
+
+在本项目里，它的直接收益是：
+
+- `customer` 可以匹配 `customers`
+- `returned` 和 `returning` 可以匹配 `return`
+- sparse recall 能更好地补充 dense retrieval
+
+### 什么时候继续用 `simple`
+
+如果你更想要“接近关键词精确匹配”的行为，`simple` 仍然更合适。比如：
+
+- SKU
+- 工单编号
+- 产品型号
+- 版本号
+- 混合语言或术语很重的文本
+
+### 什么时候应该上自定义配置
+
+如果语料同时具备下面两类特征，建议后续升级到自定义配置：
+
+- 大量英文自然语言内容，需要 stemming 提高召回
+- 同时又有大量领域术语，不能接受通用 stemming 误伤
+
+这时单纯切 `simple` 或 `english` 都不够细，应该通过 synonym、thesaurus、unaccent、stemmer 组合出一套定制配置。
+
+## 当前实现建议
+
+基于当前语料特征，这次把 sparse retrieval 从 `simple` 切到 `english` 是合理的短期修复，因为：
+
+- 当前文档内容主要是英文支持文档
+- 当前 miss 的直接原因就是英文单复数不归一
+- `english` 已经能在现有库上验证修复 `customer -> customers` 的召回问题
+
+如果后续检索场景扩展到多语言或高术语密度语料，再考虑升级到自定义 PostgreSQL 文本搜索配置，而不是简单切回 `simple`。
+
+## 配置化实现说明
+
+当前代码已经把文本搜索配置做成应用配置项：
+
+- 配置路径：`app.ai.rag.sparse.text-search-config`
+- 默认值：`english`
+
+对应实现通过 `CAST(? AS regconfig)` 把配置名作为 SQL 参数传入，而不是直接把配置名拼进 SQL 字符串。
+
+这样做有两个好处：
+
+- 避免了 `text block + append` 这类字符串拼接带来的 Java 语法问题
+- 保留了配置化能力，后续可以从 `english` 切到 `simple` 或自定义 config，而不需要改代码
+
+## 常用排查 SQL
+
+查看可用配置：
+
+```sql
+SELECT cfgname FROM pg_catalog.pg_ts_config ORDER BY cfgname;
+```
+
+查看词项归一结果：
+
+```sql
+SELECT ts_debug('simple', 'customer customers returned returning');
+SELECT ts_debug('english', 'customer customers returned returning');
+```
+
+查看查询归一结果：
+
+```sql
+SELECT websearch_to_tsquery('simple', 'customer');
+SELECT websearch_to_tsquery('english', 'customer');
+```
+
+查看命中数量：
+
+```sql
+SELECT COUNT(*)
+FROM vector_store
+WHERE to_tsvector('english', content) @@ websearch_to_tsquery('english', 'customer');
+```
+
+## 参考资料
+
+- PostgreSQL Full Text Search introduction
+- PostgreSQL Controlling Text Search
+- PostgreSQL Dictionaries
+- PostgreSQL Configuration Example
+
+本次整理参考的官方文档：
+
+- https://www.postgresql.org/docs/current/textsearch-intro.html
+- https://www.postgresql.org/docs/current/textsearch-controls.html
+- https://www.postgresql.org/docs/current/textsearch-dictionaries.html
+- https://www.postgresql.org/docs/current/textsearch-configuration.html

--- a/src/main/java/com/dawn/ai/agent/orchestration/AgentOrchestrator.java
+++ b/src/main/java/com/dawn/ai/agent/orchestration/AgentOrchestrator.java
@@ -32,6 +32,7 @@ import java.util.List;
 import java.util.function.BooleanSupplier;
 import java.util.function.Consumer;
 import java.util.Map;
+import java.util.stream.Stream;
 
 /**
  * Agent Orchestrator — orchestrates the full ReAct loop with planning and step tracing.
@@ -205,7 +206,7 @@ public class AgentOrchestrator {
                     .toolNames(toolRegistry.getNames())
                     .stream()
                     .chatResponse()
-                    .contextCapture()
+                    .contextCapture() // 在当前 pipeline 订阅点主动把所有已注册 ThreadLocal 快照进 Reactor Context
                     .takeWhile(chunk -> !isCancelled.getAsBoolean())
                     .doOnNext(chunk -> {
                         String reasoning = extractReasoning(chunk);

--- a/src/main/java/com/dawn/ai/config/AgentConfig.java
+++ b/src/main/java/com/dawn/ai/config/AgentConfig.java
@@ -53,6 +53,21 @@ public class AgentConfig {
         );
     }
 
+    @Bean(name = "ragRetrievalExecutor", destroyMethod = "shutdown")
+    public ExecutorService ragRetrievalExecutor() {
+        return new ThreadPoolExecutor(
+                4, 16,
+                60L, TimeUnit.SECONDS,
+                new LinkedBlockingQueue<>(128),
+                r -> {
+                    Thread t = new Thread(r, "rag-retrieval-" + System.nanoTime());
+                    t.setDaemon(true);
+                    return t;
+                },
+                new ThreadPoolExecutor.CallerRunsPolicy()
+        );
+    }
+
     /**
      * Enables Micrometer context propagation for the reactive (Reactor) pipeline.
      *
@@ -75,8 +90,10 @@ public class AgentConfig {
     @Bean
     public ApplicationRunner enableReactorContextPropagation() {
         return args -> {
+            // 告诉 Micrometer：存在一个 ThreadLocal 需要传播
             ContextRegistry.getInstance()
                     .registerThreadLocalAccessor(new StepCollectorContextAccessor());
+            // 告诉 Reactor：每次切换线程前自动调用所有 Accessor 的 set/restore
             Hooks.enableAutomaticContextPropagation();
             log.info("[AgentConfig] Reactor automatic context propagation enabled (StepCollector)");
         };

--- a/src/main/java/com/dawn/ai/rag/RagService.java
+++ b/src/main/java/com/dawn/ai/rag/RagService.java
@@ -12,7 +12,6 @@ import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.DistributionSummary;
 import io.micrometer.core.instrument.MeterRegistry;
 import jakarta.annotation.PostConstruct;
-import lombok.RequiredArgsConstructor;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.ai.document.Document;
@@ -21,6 +20,7 @@ import org.springframework.ai.vectorstore.SearchRequest;
 import org.springframework.ai.vectorstore.VectorStore;
 import org.springframework.ai.vectorstore.filter.Filter;
 import org.springframework.ai.vectorstore.filter.FilterExpressionBuilder;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
@@ -28,6 +28,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
 
 /**
  * RAG (Retrieval Augmented Generation) Service.
@@ -37,7 +39,6 @@ import java.util.UUID;
  */
 @Slf4j
 @Service
-@RequiredArgsConstructor
 public class RagService {
 
     private final VectorStore vectorStore;
@@ -48,6 +49,30 @@ public class RagService {
     private final ReciprocalRankFusion reciprocalRankFusion;
     private final RetrievalRouter retrievalRouter;
     private final DocumentTransformer splitter;
+    // Keep an explicit constructor with parameter-level @Qualifier because the
+    // application defines multiple ExecutorService beans and this dependency must
+    // bind to the retrieval pool rather than relying on type-only resolution.
+    private final ExecutorService ragRetrievalExecutor;
+
+    public RagService(VectorStore vectorStore,
+                      MeterRegistry meterRegistry,
+                      AiAvailabilityChecker aiAvailabilityChecker,
+                      RetrievalReranker retrievalReranker,
+                      SparseRetriever sparseRetriever,
+                      ReciprocalRankFusion reciprocalRankFusion,
+                      RetrievalRouter retrievalRouter,
+                      DocumentTransformer splitter,
+                      @Qualifier("ragRetrievalExecutor") ExecutorService ragRetrievalExecutor) {
+        this.vectorStore = vectorStore;
+        this.meterRegistry = meterRegistry;
+        this.aiAvailabilityChecker = aiAvailabilityChecker;
+        this.retrievalReranker = retrievalReranker;
+        this.sparseRetriever = sparseRetriever;
+        this.reciprocalRankFusion = reciprocalRankFusion;
+        this.retrievalRouter = retrievalRouter;
+        this.splitter = splitter;
+        this.ragRetrievalExecutor = ragRetrievalExecutor;
+    }
 
     @Setter
     @Value("${app.ai.rag.similarity-threshold:0.7}")
@@ -139,11 +164,24 @@ public class RagService {
         SearchRequest request = builder.build();
 
         RetrievalStrategy strategy = resolveStrategy(retrievalRequest);
-        List<Document> denseResults = vectorStore.similaritySearch(request);
-        List<Document> sparseResults = shouldUseHybridSearch(strategy) ? sparseRetriever.retrieve(retrievalRequest, candidateCount) : List.of();
+        CompletableFuture<List<Document>> denseFuture = CompletableFuture.supplyAsync(
+            () -> vectorStore.similaritySearch(request),
+            ragRetrievalExecutor);
+        CompletableFuture<List<Document>> sparseFuture = CompletableFuture.supplyAsync(() -> shouldUseHybridSearch(strategy)
+                ? sparseRetriever.retrieve(retrievalRequest, candidateCount)
+                : List.of(),
+            ragRetrievalExecutor);
+
+        CompletableFuture.allOf(denseFuture, sparseFuture).join();
+
+        List<Document> denseResults = denseFuture.join();
+        List<Document> sparseResults = sparseFuture.join();
+        log.debug("[RagService] Retrieval candidates: dense={}, sparse={}, strategy={}, query='{}'",
+            denseResults.size(), sparseResults.size(), strategy, retrievalRequest.getQuery());
         List<Document> results = shouldUseHybridSearch(strategy)
-                ? reciprocalRankFusion.fuse(denseResults, sparseResults)
-                : denseResults;
+            ? reciprocalRankFusion.fuse(denseResults, sparseResults)
+            : denseResults;
+
         int filteredOut = Math.max(0, candidateCount - denseResults.size());
         filteredCountSummary.record(filteredOut);
 

--- a/src/main/java/com/dawn/ai/rag/retrieval/RetrievalRouter.java
+++ b/src/main/java/com/dawn/ai/rag/retrieval/RetrievalRouter.java
@@ -20,12 +20,23 @@ public class RetrievalRouter {
         }
 
         List<String> tokens = tokenize(request.getQuery());
+        // Heuristic: it's likely keyword-based
+        // - 短查询（通常是核心名词）更适合关键词搜索
+        // - 如果用户使用了引号，通常代表精确匹配需求
+        // - 包含数字（如型号、日期、ID）。向量模型对精确数字的敏感度通常不如传统的关键词检索
         boolean keywordLike = tokens.size() <= 3
                 || request.getQuery().contains("\"")
                 || request.getQuery().matches(".*\\d.*");
         return keywordLike ? RetrievalStrategy.HYBRID : RetrievalStrategy.DENSE;
     }
 
+    /*
+     * 预处理分词：
+     * 1. 将查询字符串转换为小写
+     * 2. 使用预定义的正则表达式将查询字符串拆分为单词列表
+     * 3. 过滤掉空白或无效的单词
+     * 4. 返回处理后的单词列表
+     */
     private List<String> tokenize(String query) {
         return TOKEN_SPLITTER.splitAsStream(query.toLowerCase(Locale.ROOT))
                 .filter(token -> !token.isBlank())

--- a/src/main/java/com/dawn/ai/rag/retrieval/sparse/PostgresBm25Retriever.java
+++ b/src/main/java/com/dawn/ai/rag/retrieval/sparse/PostgresBm25Retriever.java
@@ -4,6 +4,7 @@ import com.dawn.ai.rag.retrieval.RetrievalRequest;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.ai.document.Document;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Component;
@@ -23,28 +24,38 @@ public class PostgresBm25Retriever implements SparseRetriever {
     private final JdbcTemplate jdbcTemplate;
     private final ObjectMapper objectMapper;
 
+    @Value("${app.ai.rag.sparse.text-search-config:english}")
+    private String textSearchConfig = "english";
+
     @Override
     public List<Document> retrieve(RetrievalRequest request, int limit) {
         if (request.getQuery() == null || request.getQuery().isBlank()) {
             return List.of();
         }
 
+        // Keep regconfig parameterized so the search config is application-configurable
+        // without fragile string interpolation inside SQL text blocks.
         StringBuilder sql = new StringBuilder("""
                 SELECT id, content, metadata
                 FROM vector_store
-                WHERE to_tsvector('simple', content) @@ websearch_to_tsquery('simple', ?)
+            WHERE to_tsvector(CAST(? AS regconfig), content)
+              @@ websearch_to_tsquery(CAST(? AS regconfig), ?)
                 """);
         List<Object> params = new ArrayList<>();
+        params.add(textSearchConfig);
+        params.add(textSearchConfig);
         params.add(request.getQuery());
         appendMetadataFilters(sql, params, request.getMetadataFilters());
         sql.append("""
                 
                 ORDER BY ts_rank_cd(
-                    to_tsvector('simple', content),
-                    websearch_to_tsquery('simple', ?)
+                to_tsvector(CAST(? AS regconfig), content),
+                websearch_to_tsquery(CAST(? AS regconfig), ?)
                 ) DESC
                 LIMIT ?
                 """);
+        params.add(textSearchConfig);
+        params.add(textSearchConfig);
         params.add(request.getQuery());
         params.add(limit);
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -85,6 +85,8 @@ app:
       reranker:
         type: heuristic           # heuristic | cross-encoder
       hybrid-enabled: true        # 是否启用 BM25 + Dense 混合召回
+      sparse:
+        text-search-config: english  # PostgreSQL FTS 配置名，例如 english | simple | custom config
       cross-encoder:
         base-url: ""              # 可选：cross-encoder rerank 服务地址，例如 http://localhost:8081
         rerank-path: /rerank      # rerank 接口路径，默认请求体含 query/documents/top_n

--- a/src/test/java/com/dawn/ai/rag/RagServiceTest.java
+++ b/src/test/java/com/dawn/ai/rag/RagServiceTest.java
@@ -9,6 +9,7 @@ import com.dawn.ai.rag.retrieval.RetrievalRequest;
 import com.dawn.ai.rag.retrieval.RetrievalRouter;
 import com.dawn.ai.rag.retrieval.sparse.SparseRetriever;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -22,6 +23,8 @@ import org.springframework.ai.vectorstore.VectorStore;
 
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.within;
@@ -38,11 +41,13 @@ class RagServiceTest {
     @Mock private OverlapTextSplitter overlapTextSplitter;
 
     private SimpleMeterRegistry meterRegistry;
+    private ExecutorService ragRetrievalExecutor;
     private RagService ragService;
 
     @BeforeEach
     void setUp() {
         meterRegistry = new SimpleMeterRegistry();
+        ragRetrievalExecutor = Executors.newFixedThreadPool(2);
         ragService = new RagService(
                 vectorStore,
                 meterRegistry,
@@ -51,12 +56,18 @@ class RagServiceTest {
                 sparseRetriever,
                 new ReciprocalRankFusion(),
                 new RetrievalRouter(),
-                overlapTextSplitter);
+                overlapTextSplitter,
+                ragRetrievalExecutor);
         // 注入配置值（与 application.yml 一致）
         ragService.setSimilarityThreshold(0.7);
         ragService.setHybridEnabled(false);
         // @PostConstruct 在直接 new 时不自动执行，手动初始化指标
         ragService.initMetrics();
+    }
+
+    @AfterEach
+    void tearDown() {
+        ragRetrievalExecutor.shutdownNow();
     }
 
     // ── ingest 测试 ────────────────────────────────────────────


### PR DESCRIPTION
RAG：
- 支持regconfig配置化
- 并发重构：使用 `CompletableFuture.supplyAsync()` 将 BM25 检索和向量检索改为**并发执行**，使用 `allOf().join()` 统一收集结果，将串行耗时压缩为最大单路耗时。