### PR TITLE
feat(rag): support multi-document-type file ingest and token-aware chunking

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,7 +25,7 @@ services:
       - BASE_URL=${BASE_URL}
       - CHAT_MODEL=${CHAT_MODEL}
       - EMBEDDING_MODEL=${EMBEDDING_MODEL:-BAAI/bge-m3}
-      - EMBEDDING_BASE_URL=http://host.docker.internal:${EMBEDDING_PORT:-7997} # 本地开发时直接访问宿主机地址，生产环境请替换为实际值
+      - EMBEDDING_BASE_URL=${EMBEDDING_BASE_URL} # 本地开发时直接访问宿主机地址，生产环境请替换为实际值
       - EMBEDDING_API_KEY=${EMBEDDING_API_KEY:-local-embedding-key} # 当前embedding container不做鉴权，直接使用固定值；生产环境请替换为实际值并做好安全防护
       - EMBEDDING_DIMENSIONS=${EMBEDDING_DIMENSIONS:-1024}
       - SPRING_DATASOURCE_URL=jdbc:postgresql://postgres:5432/dawn_ai

--- a/pom.xml
+++ b/pom.xml
@@ -65,6 +65,18 @@
             <artifactId>spring-ai-pdf-document-reader</artifactId>
         </dependency>
 
+        <!-- Apache Tika - Multi-format document text extraction -->
+        <dependency>
+            <groupId>org.apache.tika</groupId>
+            <artifactId>tika-core</artifactId>
+            <version>2.9.2</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.tika</groupId>
+            <artifactId>tika-parsers-standard-package</artifactId>
+            <version>2.9.2</version>
+        </dependency>
+
         <!-- Spring Data Redis -->
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -59,12 +59,6 @@
             <artifactId>spring-ai-starter-vector-store-pgvector</artifactId>
         </dependency>
 
-        <!-- Spring AI - PDF Document Reader -->
-        <dependency>
-            <groupId>org.springframework.ai</groupId>
-            <artifactId>spring-ai-pdf-document-reader</artifactId>
-        </dependency>
-
         <!-- Apache Tika - Multi-format document text extraction -->
         <dependency>
             <groupId>org.apache.tika</groupId>

--- a/src/main/java/com/dawn/ai/agent/orchestration/AgentOrchestrator.java
+++ b/src/main/java/com/dawn/ai/agent/orchestration/AgentOrchestrator.java
@@ -220,7 +220,7 @@ public class AgentOrchestrator {
                             sink.accept(ChatStreamEvent.token(sessionId, delta, answer.length()));
                         }
                         if ((reasoning != null && !reasoning.isBlank()) || (delta != null && !delta.isBlank())) {
-                            log.debug("[AI STREAM] chunk session={}, reasoningChars={}, answerChars={}, deltaChars={}",
+                            log.trace("[AI STREAM] chunk session={}, reasoningChars={}, answerChars={}, deltaChars={}",
                                     sessionId,
                                     reasoning != null ? reasoning.length() : 0,
                                     answer.length(),

--- a/src/main/java/com/dawn/ai/config/AiConfig.java
+++ b/src/main/java/com/dawn/ai/config/AiConfig.java
@@ -82,12 +82,7 @@ public class AiConfig {
 
             log.info("[AI HTTP] <-- status={} | {}", response.getStatusCode(), summarizeResponseBody(responseBodyText));
             if (log.isDebugEnabled()) {
-                try {
-                    Object parsed = OBJECT_MAPPER.readValue(responseBodyText, Object.class);
-                    log.debug("[AI HTTP] <-- full response body:\n{}", OBJECT_MAPPER.writerWithDefaultPrettyPrinter().writeValueAsString(parsed));
-                } catch (Exception ignored) {
-                    log.debug("[AI HTTP] <-- full response body: {}", responseBodyText);
-                }
+                log.debug("[AI HTTP] <-- response body detail:\n{}", formatDebugResponseBody(responseBodyText));
             }
 
             return response;
@@ -157,6 +152,14 @@ public class AiConfig {
                     }
                 }
             }
+            if (root.has("input")) {
+                JsonNode input = root.get("input");
+                sb.append(", inputs=").append(input.isArray() ? input.size() : 1);
+                String firstInput = extractFirstInputSnippet(input);
+                if (!firstInput.isBlank()) {
+                    sb.append(", firstInput=「").append(firstInput).append("」");
+                }
+            }
             if (root.has("tools")) {
                 sb.append(", tools=").append(root.get("tools").size());
             }
@@ -176,12 +179,13 @@ public class AiConfig {
         try {
             JsonNode root = OBJECT_MAPPER.readTree(body);
             StringBuilder sb = new StringBuilder();
+            appendEmbeddingSummary(sb, root);
             if (root.has("choices") && root.get("choices").size() > 0) {
                 JsonNode choice = root.get("choices").get(0);
                 sb.append("finishReason=").append(choice.path("finish_reason").asText("?"));
                 String content = choice.path("message").path("content").asText("");
                 if (!content.isBlank()) {
-                    sb.append(", content=「").append(content).append("」");
+                    sb.append(", content=「").append(snippet(content)).append("」");
                 }
                 JsonNode toolCalls = choice.path("message").path("tool_calls");
                 if (toolCalls.isArray() && !toolCalls.isEmpty()) {
@@ -196,14 +200,25 @@ public class AiConfig {
             if (root.has("usage")) {
                 JsonNode usage = root.get("usage");
                 if (!sb.isEmpty()) sb.append(", ");
-                sb.append("promptTokens=").append(usage.path("prompt_tokens").asInt())
-                  .append(", completionTokens=").append(usage.path("completion_tokens").asInt());
+                appendUsageSummary(sb, usage);
             }
             if (root.has("error")) {
                 sb.append(", error=").append(root.get("error").path("message").asText());
             }
             return sb.isEmpty() ? snippet(body) : sb.toString();
         } catch (Exception e) {
+            return snippet(body);
+        }
+    }
+
+    private String formatDebugResponseBody(String body) {
+        try {
+            JsonNode root = OBJECT_MAPPER.readTree(body);
+            if (isEmbeddingResponse(root)) {
+                return summarizeResponseBody(body) + ", embeddingValues=<omitted>";
+            }
+            return OBJECT_MAPPER.writerWithDefaultPrettyPrinter().writeValueAsString(root);
+        } catch (Exception ignored) {
             return snippet(body);
         }
     }
@@ -227,6 +242,67 @@ public class AiConfig {
     private String snippet(String value) {
         if (value == null || value.length() <= MAX_CONTENT_SNIPPET) return value;
         return value.substring(0, MAX_CONTENT_SNIPPET) + "…";
+    }
+
+    private String extractFirstInputSnippet(JsonNode input) {
+        if (input == null || input.isMissingNode() || input.isNull()) {
+            return "";
+        }
+        if (input.isTextual()) {
+            return snippet(input.asText());
+        }
+        if (input.isArray() && !input.isEmpty()) {
+            JsonNode first = input.get(0);
+            if (first.isTextual()) {
+                return snippet(first.asText());
+            }
+            return snippet(first.toString());
+        }
+        return snippet(input.toString());
+    }
+
+    private void appendEmbeddingSummary(StringBuilder sb, JsonNode root) {
+        if (!isEmbeddingResponse(root)) {
+            return;
+        }
+        JsonNode data = root.path("data");
+        if (!sb.isEmpty()) {
+            sb.append(", ");
+        }
+        sb.append("embeddings=").append(data.size());
+        JsonNode firstEmbedding = data.isEmpty() ? null : data.get(0).path("embedding");
+        if (firstEmbedding != null && firstEmbedding.isArray()) {
+            sb.append(", dimensions=").append(firstEmbedding.size());
+        }
+        if (root.has("model")) {
+            sb.append(", model=").append(root.path("model").asText());
+        }
+    }
+
+    private void appendUsageSummary(StringBuilder sb, JsonNode usage) {
+        boolean appended = false;
+        if (usage.has("prompt_tokens")) {
+            sb.append("promptTokens=").append(usage.path("prompt_tokens").asInt());
+            appended = true;
+        }
+        if (usage.has("completion_tokens")) {
+            if (appended) {
+                sb.append(", ");
+            }
+            sb.append("completionTokens=").append(usage.path("completion_tokens").asInt());
+            appended = true;
+        }
+        if (usage.has("total_tokens")) {
+            if (appended) {
+                sb.append(", ");
+            }
+            sb.append("totalTokens=").append(usage.path("total_tokens").asInt());
+        }
+    }
+
+    private boolean isEmbeddingResponse(JsonNode root) {
+        JsonNode data = root.path("data");
+        return data.isArray() && !data.isEmpty() && data.get(0).has("embedding");
     }
 
     private HttpHeaders sanitizeHeaders(ClientRequest request) {

--- a/src/main/java/com/dawn/ai/controller/RagController.java
+++ b/src/main/java/com/dawn/ai/controller/RagController.java
@@ -2,6 +2,8 @@ package com.dawn.ai.controller;
 
 import com.dawn.ai.dto.RagRequest;
 import com.dawn.ai.rag.RagService;
+import com.dawn.ai.rag.constants.DocumentType;
+import com.dawn.ai.rag.ingestion.DocumentTextExtractor;
 import com.dawn.ai.rag.retrieval.RetrievalRequest;
 import com.dawn.ai.rag.retrieval.RetrievalStrategy;
 import jakarta.validation.Valid;
@@ -10,12 +12,15 @@ import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.ai.document.Document;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 
 @Slf4j
@@ -26,14 +31,39 @@ import java.util.Map;
 public class RagController {
 
     private final RagService ragService;
+    private final DocumentTextExtractor documentTextExtractor;
 
     /**
      * Ingest a document into the vector knowledge base.
      */
-    @PostMapping("/ingest")
+    @PostMapping(value = "/ingest", consumes = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<Map<String, String>> ingest(@Valid @RequestBody RagRequest request) {
         String docId = ragService.ingest(request.getContent(), request.getSource(), request.getCategory());
         return ResponseEntity.ok(Map.of("docId", docId, "status", "ingested"));
+    }
+
+    /**
+     * Ingest file uploads for multiple document types (text/pdf/word/excel).
+     */
+    @PostMapping(value = "/ingest", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<Map<String, String>> ingestFile(
+            @RequestPart("file") MultipartFile file,
+            @RequestParam(required = false) DocumentType documentType,
+            @RequestParam(required = false) String source,
+            @RequestParam(required = false) String category) {
+        if (file.isEmpty()) {
+            throw new IllegalArgumentException("Uploaded file is empty");
+        }
+
+        DocumentType resolvedType = documentType != null ? documentType : inferDocumentType(file);
+        String content = documentTextExtractor.extract(file, resolvedType);
+        String effectiveSource = (source != null && !source.isBlank()) ? source : file.getOriginalFilename();
+        String docId = ragService.ingest(content, effectiveSource, category);
+        return ResponseEntity.ok(Map.of(
+                "docId", docId,
+                "status", "ingested",
+                "documentType", resolvedType.name()
+        ));
     }
 
     /**
@@ -72,5 +102,54 @@ public class RagController {
         if (values != null && !values.isEmpty()) {
             filters.put(key, values);
         }
+    }
+
+    private DocumentType inferDocumentType(MultipartFile file) {
+        String filename = file.getOriginalFilename() != null
+                ? file.getOriginalFilename().toLowerCase(Locale.ROOT)
+                : "";
+        String contentType = file.getContentType() != null
+                ? file.getContentType().toLowerCase(Locale.ROOT)
+                : "";
+
+        if (isTextDocument(filename, contentType)) {
+            return DocumentType.TEXT;
+        }
+        if (isPdfDocument(filename, contentType)) {
+            return DocumentType.PDF;
+        }
+        if (isWordDocument(filename, contentType)) {
+            return DocumentType.WORD;
+        }
+        if (isExcelDocument(filename, contentType)) {
+            return DocumentType.EXCEL;
+        }
+
+        throw new IllegalArgumentException("Unsupported file format. Supported: text/pdf/word/excel");
+    }
+
+    private boolean isTextDocument(String filename, String contentType) {
+        return filename.endsWith(".txt")
+                || filename.endsWith(".md")
+                || filename.endsWith(".csv")
+                || contentType.startsWith("text/");
+    }
+
+    private boolean isPdfDocument(String filename, String contentType) {
+        return filename.endsWith(".pdf") || "application/pdf".equals(contentType);
+    }
+
+    private boolean isWordDocument(String filename, String contentType) {
+        return filename.endsWith(".doc")
+                || filename.endsWith(".docx")
+                || "application/msword".equals(contentType)
+                || "application/vnd.openxmlformats-officedocument.wordprocessingml.document".equals(contentType);
+    }
+
+    private boolean isExcelDocument(String filename, String contentType) {
+        return filename.endsWith(".xls")
+                || filename.endsWith(".xlsx")
+                || "application/vnd.ms-excel".equals(contentType)
+                || "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet".equals(contentType);
     }
 }

--- a/src/main/java/com/dawn/ai/exception/ApiExceptionHandler.java
+++ b/src/main/java/com/dawn/ai/exception/ApiExceptionHandler.java
@@ -62,6 +62,14 @@ public class ApiExceptionHandler {
         return buildResponse(HttpStatus.BAD_REQUEST, exception.getMessage(), request.getRequestURI());
     }
 
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<Map<String, Object>> handleIllegalArgument(
+            IllegalArgumentException exception,
+            HttpServletRequest request) {
+        recordError("validation_error");
+        return buildResponse(HttpStatus.BAD_REQUEST, exception.getMessage(), request.getRequestURI());
+    }
+
     @ExceptionHandler(PlanGenerationException.class)
     public ResponseEntity<Map<String, Object>> handlePlanGeneration(
             PlanGenerationException exception,

--- a/src/main/java/com/dawn/ai/rag/RagService.java
+++ b/src/main/java/com/dawn/ai/rag/RagService.java
@@ -117,11 +117,13 @@ public class RagService {
     public String ingest(String content, String source, String category) {
         aiAvailabilityChecker.ensureConfigured();
 
+        String docId = UUID.randomUUID().toString();
         Map<String, Object> metadata = Map.of(
                 "source", source != null ? source : "manual",
-                "category", category != null ? category : "general"
+                "category", category != null ? category : "general",
+                "docId", docId
         );
-        Document parentDoc = new Document(UUID.randomUUID().toString(), content, metadata);
+        Document parentDoc = new Document(docId, content, metadata);
 
         List<Document> chunks = splitter.apply(List.of(parentDoc));
 
@@ -129,7 +131,7 @@ public class RagService {
         ingestionCounter.increment(chunks.size());
 
         log.info("[RagService] Ingested {} chunk(s), source={}", chunks.size(), source);
-        return parentDoc.getId();
+        return docId;
     }
 
     /**

--- a/src/main/java/com/dawn/ai/rag/constants/DocumentType.java
+++ b/src/main/java/com/dawn/ai/rag/constants/DocumentType.java
@@ -1,0 +1,8 @@
+package com.dawn.ai.rag.constants;
+
+public enum DocumentType {
+    TEXT,
+    PDF,
+    WORD,
+    EXCEL
+}

--- a/src/main/java/com/dawn/ai/rag/ingestion/DocumentTextExtractor.java
+++ b/src/main/java/com/dawn/ai/rag/ingestion/DocumentTextExtractor.java
@@ -47,7 +47,7 @@ public class DocumentTextExtractor {
             ParseContext parseContext = new ParseContext();
             parser.parse(inputStream, handler, metadata, parseContext);
             return handler.toString();
-        } catch (IOException | SAXException | TikaException e) {
+        } catch (Exception e) {
             log.warn("[DocumentTextExtractor] Failed to parse file: {}", file.getOriginalFilename(), e);
             throw new IllegalArgumentException("Unsupported or corrupted document content", e);
         }

--- a/src/main/java/com/dawn/ai/rag/ingestion/DocumentTextExtractor.java
+++ b/src/main/java/com/dawn/ai/rag/ingestion/DocumentTextExtractor.java
@@ -1,0 +1,55 @@
+package com.dawn.ai.rag.ingestion;
+
+import com.dawn.ai.rag.constants.DocumentType;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.tika.exception.TikaException;
+import org.apache.tika.metadata.Metadata;
+import org.apache.tika.metadata.TikaCoreProperties;
+import org.apache.tika.parser.AutoDetectParser;
+import org.apache.tika.parser.ParseContext;
+import org.apache.tika.sax.BodyContentHandler;
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+import org.xml.sax.SAXException;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+
+@Slf4j
+@Component
+public class DocumentTextExtractor {
+
+    public String extract(MultipartFile file, DocumentType documentType) {
+        try (InputStream inputStream = file.getInputStream()) {
+            String text = switch (documentType) {
+                case TEXT -> new String(inputStream.readAllBytes(), StandardCharsets.UTF_8);
+                case PDF, WORD, EXCEL -> extractWithTika(inputStream, file);
+            };
+
+            if (text == null || text.isBlank()) {
+                throw new IllegalArgumentException("No textual content could be extracted from file");
+            }
+            return text;
+        } catch (IOException e) {
+            throw new IllegalArgumentException("Failed to read uploaded file", e);
+        }
+    }
+
+    private String extractWithTika(InputStream inputStream, MultipartFile file) {
+        try {
+            AutoDetectParser parser = new AutoDetectParser();
+            BodyContentHandler handler = new BodyContentHandler(-1);
+            Metadata metadata = new Metadata();
+            if (file.getOriginalFilename() != null && !file.getOriginalFilename().isBlank()) {
+                metadata.set(TikaCoreProperties.RESOURCE_NAME_KEY, file.getOriginalFilename());
+            }
+            ParseContext parseContext = new ParseContext();
+            parser.parse(inputStream, handler, metadata, parseContext);
+            return handler.toString();
+        } catch (IOException | SAXException | TikaException e) {
+            log.warn("[DocumentTextExtractor] Failed to parse file: {}", file.getOriginalFilename(), e);
+            throw new IllegalArgumentException("Unsupported or corrupted document content", e);
+        }
+    }
+}

--- a/src/main/java/com/dawn/ai/rag/ingestion/OverlapTextSplitter.java
+++ b/src/main/java/com/dawn/ai/rag/ingestion/OverlapTextSplitter.java
@@ -1,36 +1,85 @@
 package com.dawn.ai.rag.ingestion;
 
-import lombok.RequiredArgsConstructor;
-import lombok.Setter;
+import com.knuddels.jtokkit.Encodings;
+import com.knuddels.jtokkit.api.Encoding;
+import com.knuddels.jtokkit.api.EncodingRegistry;
+import com.knuddels.jtokkit.api.EncodingType;
+import com.knuddels.jtokkit.api.IntArrayList;
 import org.springframework.ai.document.Document;
 import org.springframework.ai.document.DocumentTransformer;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.context.annotation.Configuration;
 import org.springframework.stereotype.Component;
 
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 
 /**
- * Simple whitespace-based splitter with configurable overlap.
+ * Token-aware splitter with configurable overlap and punctuation-aware boundaries.
  */
 @Component
 public class OverlapTextSplitter implements DocumentTransformer {
+    private static final int DEFAULT_MIN_CHUNK_SIZE_CHARS = 350;
+    private static final int DEFAULT_MIN_CHUNK_LENGTH_TO_EMBED = 5;
+    private static final int DEFAULT_MAX_NUM_CHUNKS = 10_000;
+    private static final List<Character> DEFAULT_PUNCTUATION_MARKS = List.of('.', '?', '!', '\n');
+
+    private final Encoding encoding;
     private final int chunkSize;
     private final int chunkOverlap;
+    private final int minChunkSizeChars;
+    private final int minChunkLengthToEmbed;
+    private final int maxNumChunks;
+    private final List<Character> punctuationMarks;
 
+    @Autowired
     public OverlapTextSplitter(@Value("${app.ai.rag.chunk-size:500}") int chunkSize,
                                @Value("${app.ai.rag.chunk-overlap:50}") int chunkOverlap) {
+        this(chunkSize,
+                chunkOverlap,
+                DEFAULT_MIN_CHUNK_SIZE_CHARS,
+                DEFAULT_MIN_CHUNK_LENGTH_TO_EMBED,
+                DEFAULT_MAX_NUM_CHUNKS,
+                DEFAULT_PUNCTUATION_MARKS);
+    }
+
+    private OverlapTextSplitter(int chunkSize,
+                        int chunkOverlap,
+                        int minChunkSizeChars,
+                        int minChunkLengthToEmbed,
+                        int maxNumChunks,
+                        List<Character> punctuationMarks) {
         if (chunkSize <= 0) {
             throw new IllegalArgumentException("chunkSize must be positive");
         }
         if (chunkOverlap < 0 || chunkOverlap >= chunkSize) {
             throw new IllegalArgumentException("chunkOverlap must be >= 0 and < chunkSize");
         }
+        if (minChunkSizeChars < 0) {
+            throw new IllegalArgumentException("minChunkSizeChars must be >= 0");
+        }
+        if (minChunkLengthToEmbed < 0) {
+            throw new IllegalArgumentException("minChunkLengthToEmbed must be >= 0");
+        }
+        if (maxNumChunks <= 0) {
+            throw new IllegalArgumentException("maxNumChunks must be positive");
+        }
+        if (punctuationMarks == null || punctuationMarks.isEmpty()) {
+            throw new IllegalArgumentException("punctuationMarks must not be empty");
+        }
+
+        EncodingRegistry registry = Encodings.newLazyEncodingRegistry();
+        this.encoding = registry.getEncoding(EncodingType.CL100K_BASE);
         this.chunkSize = chunkSize;
         this.chunkOverlap = chunkOverlap;
+        this.minChunkSizeChars = minChunkSizeChars;
+        this.minChunkLengthToEmbed = minChunkLengthToEmbed;
+        this.maxNumChunks = maxNumChunks;
+        this.punctuationMarks = List.copyOf(punctuationMarks);
     }
 
     @Override
@@ -48,33 +97,94 @@ public class OverlapTextSplitter implements DocumentTransformer {
             return List.of(document);
         }
 
-        String[] tokens = text.trim().split("\\s+");
-        if (tokens.length <= chunkSize) {
-            Map<String, Object> metadata = new LinkedHashMap<>(document.getMetadata());
-            metadata.put("parentDocumentId", document.getId());
-            metadata.put("chunkIndex", 0);
-            metadata.put("chunkCount", 1);
-            return List.of(new Document(document.getId(), text.trim(), metadata));
+        String normalizedText = text.trim();
+        IntArrayList tokens = encoding.encode(normalizedText);
+        if (tokens.size() <= chunkSize) {
+            return List.of(createChunk(document, normalizedText, 0, 1));
         }
 
-        int step = chunkSize - chunkOverlap;
         List<String> chunkTexts = new ArrayList<>();
-        for (int start = 0; start < tokens.length; start += step) {
-            int end = Math.min(start + chunkSize, tokens.length);
-            chunkTexts.add(String.join(" ", List.of(tokens).subList(start, end)));
-            if (end >= tokens.length) {
+        int start = 0;
+        while (start < tokens.size() && chunkTexts.size() < maxNumChunks) {
+            int end = Math.min(start + chunkSize, tokens.size());
+            String chunkText = decode(tokens, start, end);
+            String normalizedChunk = normalizeChunk(chunkText, tokens.size() > chunkSize);
+
+            if (normalizedChunk.length() > minChunkLengthToEmbed) {
+                chunkTexts.add(normalizedChunk);
+            }
+
+            if (end >= tokens.size()) {
                 break;
             }
+
+            int consumedTokens = countConsumedTokens(chunkText, normalizedChunk);
+            start += Math.max(consumedTokens - chunkOverlap, 1);
         }
 
         List<Document> chunks = new ArrayList<>(chunkTexts.size());
         for (int index = 0; index < chunkTexts.size(); index++) {
-            Map<String, Object> metadata = new LinkedHashMap<>(document.getMetadata());
-            metadata.put("parentDocumentId", document.getId());
-            metadata.put("chunkIndex", index);
-            metadata.put("chunkCount", chunkTexts.size());
-            chunks.add(new Document(document.getId() + "#chunk-" + index, chunkTexts.get(index), metadata));
+            chunks.add(createChunk(document, chunkTexts.get(index), index, chunkTexts.size()));
         }
         return chunks;
+    }
+
+    private Document createChunk(Document document, String text, int chunkIndex, int chunkCount) {
+        Map<String, Object> metadata = new LinkedHashMap<>(document.getMetadata());
+        metadata.put("parentDocumentId", document.getId());
+        metadata.put("chunkIndex", chunkIndex);
+        metadata.put("chunkCount", chunkCount);
+
+        String chunkId = createChunkId(document.getId(), chunkIndex, chunkCount);
+        Document chunk = new Document(chunkId, text, metadata);
+        chunk.setContentFormatter(document.getContentFormatter());
+        return chunk;
+    }
+
+    private String createChunkId(String documentId, int chunkIndex, int chunkCount) {
+        if (chunkCount == 1) {
+            return documentId;
+        }
+        return UUID.nameUUIDFromBytes((documentId + "#chunk-" + chunkIndex).getBytes(StandardCharsets.UTF_8))
+                .toString();
+    }
+
+    private String decode(IntArrayList tokens, int startInclusive, int endExclusive) {
+        IntArrayList window = new IntArrayList(endExclusive - startInclusive);
+        for (int index = startInclusive; index < endExclusive; index++) {
+            window.add(tokens.get(index));
+        }
+        return encoding.decode(window);
+    }
+
+    private String normalizeChunk(String chunkText, boolean allowPunctuationBoundary) {
+        String candidate = chunkText;
+        if (allowPunctuationBoundary) {
+            int punctuationIndex = getLastPunctuationIndex(candidate);
+            if (punctuationIndex > minChunkSizeChars) {
+                candidate = candidate.substring(0, punctuationIndex + 1);
+            }
+        }
+        return candidate.trim();
+    }
+
+    private int countConsumedTokens(String rawChunkText, String normalizedChunk) {
+        if (normalizedChunk.isBlank()) {
+            return encoding.encode(rawChunkText).size();
+        }
+
+        int consumedTokens = encoding.encode(normalizedChunk).size();
+        if (consumedTokens == 0) {
+            consumedTokens = encoding.encode(rawChunkText.trim()).size();
+        }
+        return Math.max(consumedTokens, 1);
+    }
+
+    private int getLastPunctuationIndex(String chunkText) {
+        int lastPunctuationIndex = -1;
+        for (Character punctuationMark : punctuationMarks) {
+            lastPunctuationIndex = Math.max(lastPunctuationIndex, chunkText.lastIndexOf(punctuationMark));
+        }
+        return lastPunctuationIndex;
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -2,6 +2,11 @@ spring:
   application:
     name: dawn-ai
 
+  servlet:
+    multipart:
+      max-file-size: 10MB
+      max-request-size: 100MB
+
   # DataSource (PostgreSQL with pgvector extension)
   datasource:
     url: jdbc:postgresql://localhost:5432/dawn_ai

--- a/src/main/resources/static/css/style.css
+++ b/src/main/resources/static/css/style.css
@@ -747,43 +747,75 @@ html, body {
 
 /* ===== File Upload ===== */
 .file-upload-zone {
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
     border: 2px dashed var(--border-color);
     border-radius: var(--radius-lg);
-    padding: 40px 20px;
+    padding: 36px 20px 28px;
     text-align: center;
     color: var(--text-secondary);
-    cursor: not-allowed;
-    opacity: 0.6;
-    position: relative;
+    cursor: pointer;
+    transition: border-color var(--transition), background var(--transition);
+    min-height: 160px;
+}
+
+.file-upload-zone:focus-visible,
+.file-upload-zone:hover,
+.file-upload-zone.drag-over,
+.file-upload-zone.has-file {
+    border-color: var(--accent);
+    background: var(--accent-light);
+    color: var(--text-primary);
+    outline: none;
+}
+
+.file-input-hidden {
+    display: none;
 }
 
 .file-upload-zone svg {
     margin-bottom: 12px;
+    pointer-events: none;
+    transition: transform var(--transition);
+}
+
+.file-upload-zone:hover svg {
+    transform: translateY(-3px);
 }
 
 .file-upload-zone p {
     font-size: 15px;
     font-weight: 500;
     margin-bottom: 4px;
+    pointer-events: none;
+}
+
+.upload-browse-link {
+    color: var(--accent);
+    text-decoration: underline;
 }
 
 .file-types {
     font-size: 12px;
+    pointer-events: none;
 }
 
-.file-upload-zone input {
-    display: none;
-}
-
-.coming-soon-badge {
-    text-align: center;
-    margin-top: 12px;
-    padding: 8px;
-    background: var(--bg-tertiary);
-    border-radius: var(--radius);
-    font-size: 12px;
-    color: var(--warning);
+.file-selected-name {
+    margin-top: 10px;
+    font-size: 13px;
     font-weight: 500;
+    color: var(--accent);
+    min-height: 20px;
+    pointer-events: none;
+}
+
+.form-hint-inline {
+    font-size: 12px;
+    color: var(--text-secondary);
+    font-weight: normal;
 }
 
 /* ===== Result & Search ===== */

--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -100,13 +100,35 @@
                             <div class="result-area" id="ingestResult"></div>
                         </div>
                         <div class="tab-content" id="tab-file-upload">
-                            <div class="file-upload-zone" id="fileUploadZone">
+                            <div class="file-upload-zone" id="fileUploadZone" role="button" tabindex="0">
+                                <input type="file" id="fileInput" class="file-input-hidden" accept=".txt,.md,.csv,.pdf,.doc,.docx,.xls,.xlsx">
                                 <svg width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="17 8 12 3 7 8"/><line x1="12" y1="3" x2="12" y2="15"/></svg>
-                                <p>Drag & drop files here</p>
-                                <span class="file-types">PDF, Word, TXT (Coming soon)</span>
-                                <input type="file" id="fileInput" accept=".pdf,.doc,.docx,.txt" disabled>
+                                <p>Drag &amp; drop a file here, or <span class="upload-browse-link">click to browse</span></p>
+                                <span class="file-types">TXT &middot; MD &middot; CSV &middot; PDF &middot; DOC &middot; DOCX &middot; XLS &middot; XLSX</span>
+                                <div class="file-selected-name" id="fileSelectedName"></div>
                             </div>
-                            <div class="coming-soon-badge">Backend file parsing not yet implemented</div>
+                            <div class="form-row" style="margin-top:14px">
+                                <div class="form-group">
+                                    <label for="fileSource">Source</label>
+                                    <input type="text" id="fileSource" placeholder="e.g., product-manual">
+                                </div>
+                                <div class="form-group">
+                                    <label for="fileCategory">Category</label>
+                                    <input type="text" id="fileCategory" placeholder="e.g., documentation">
+                                </div>
+                            </div>
+                            <div class="form-group">
+                                <label for="fileDocumentType">Document Type <span class="form-hint-inline">(auto-detected if not set)</span></label>
+                                <select id="fileDocumentType">
+                                    <option value="">Auto Detect</option>
+                                    <option value="TEXT">TEXT (txt / md / csv)</option>
+                                    <option value="PDF">PDF</option>
+                                    <option value="WORD">WORD (doc / docx)</option>
+                                    <option value="EXCEL">EXCEL (xls / xlsx)</option>
+                                </select>
+                            </div>
+                            <button class="btn btn-primary" id="uploadBtn" type="button" disabled>Upload &amp; Ingest</button>
+                            <div class="result-area" id="uploadResult"></div>
                         </div>
                     </section>
 

--- a/src/main/resources/static/js/app.js
+++ b/src/main/resources/static/js/app.js
@@ -15,6 +15,7 @@ const state = {
     sessionId: null,
     isLoading: false,
     streamMode: true,  // default to SSE streaming
+    knowledgeUploadFile: null,
 };
 
 // ===== DOM References =====
@@ -479,14 +480,139 @@ function initKnowledge() {
         $('#topKValue').textContent = e.target.value;
     });
 
-    // Ingest
+    // Ingest text
     $('#ingestBtn').addEventListener('click', ingestDocument);
+
+    // File upload
+    initFileUpload();
 
     // Search
     $('#searchBtn').addEventListener('click', searchDocuments);
     $('#searchQuery').addEventListener('keydown', (e) => {
         if (e.key === 'Enter') searchDocuments();
     });
+}
+
+function initFileUpload() {
+    const zone = $('#fileUploadZone');
+    const fileInput = $('#fileInput');
+    const uploadBtn = $('#uploadBtn');
+
+    const openPicker = () => fileInput.click();
+
+    zone.addEventListener('click', openPicker);
+    zone.addEventListener('keydown', (e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault();
+            openPicker();
+        }
+    });
+
+    fileInput.addEventListener('change', () => {
+        setSelectedKnowledgeFile(fileInput.files[0] || null);
+    });
+
+    zone.addEventListener('dragenter', (e) => {
+        e.preventDefault();
+        zone.classList.add('drag-over');
+    });
+    zone.addEventListener('dragover', (e) => {
+        e.preventDefault();
+        zone.classList.add('drag-over');
+    });
+    zone.addEventListener('dragleave', (e) => {
+        if (e.currentTarget.contains(e.relatedTarget)) return;
+        zone.classList.remove('drag-over');
+    });
+    zone.addEventListener('drop', (e) => {
+        e.preventDefault();
+        zone.classList.remove('drag-over');
+        setSelectedKnowledgeFile((e.dataTransfer && e.dataTransfer.files[0]) || null);
+    });
+
+    uploadBtn.addEventListener('click', ingestFile);
+}
+
+function setSelectedKnowledgeFile(file) {
+    const nameEl = $('#fileSelectedName');
+    const uploadBtn = $('#uploadBtn');
+    const zone = $('#fileUploadZone');
+
+    state.knowledgeUploadFile = file;
+    zone.classList.toggle('has-file', Boolean(file));
+
+    if (file) {
+        nameEl.textContent = `${file.name} (${formatFileSize(file.size)})`;
+        uploadBtn.disabled = false;
+    } else {
+        nameEl.textContent = '';
+        uploadBtn.disabled = true;
+        $('#fileInput').value = '';
+    }
+}
+
+function formatFileSize(bytes) {
+    if (bytes < 1024) return bytes + ' B';
+    if (bytes < 1024 * 1024) return (bytes / 1024).toFixed(1) + ' KB';
+    return (bytes / 1024 / 1024).toFixed(1) + ' MB';
+}
+
+async function ingestFile() {
+    const file = state.knowledgeUploadFile;
+    if (!file) {
+        toast('Please select a file first', 'error');
+        return;
+    }
+
+    const btn = $('#uploadBtn');
+    btn.disabled = true;
+    btn.textContent = 'Uploading...';
+
+    const formData = new FormData();
+    formData.append('file', file);
+
+    const docType = $('#fileDocumentType').value;
+    if (docType) formData.append('documentType', docType);
+
+    const source = $('#fileSource').value.trim();
+    if (source) formData.append('source', source);
+
+    const category = $('#fileCategory').value.trim();
+    if (category) formData.append('category', category);
+
+    const result = $('#uploadResult');
+    result.classList.add('show');
+    result.className = 'result-area show';
+    result.textContent = 'Uploading and parsing file...';
+
+    try {
+        const res = await fetch(API.ragIngest, {
+            method: 'POST',
+            body: formData,
+            // Do NOT set Content-Type – browser sets it with boundary automatically
+        });
+
+        if (res.ok) {
+            const data = await res.json();
+            result.className = 'result-area show success';
+            result.textContent = `Success: ${JSON.stringify(data)}`;
+            toast('File ingested successfully', 'success');
+            // Reset
+            setSelectedKnowledgeFile(null);
+        } else {
+            const err = await res.json().catch(() => ({ message: res.statusText }));
+            result.className = 'result-area show error';
+            result.textContent = `Error: ${err.message || res.statusText}`;
+            toast('Upload failed', 'error');
+        }
+    } catch (err) {
+        result.className = 'result-area show error';
+        result.textContent = `Network error: ${err.message}`;
+        toast('Network error', 'error');
+    } finally {
+        btn.disabled = !state.knowledgeUploadFile;
+        btn.textContent = 'Upload & Ingest';
+    }
 }
 
 async function ingestDocument() {

--- a/src/test/java/com/dawn/ai/config/AiConfigTest.java
+++ b/src/test/java/com/dawn/ai/config/AiConfigTest.java
@@ -1,0 +1,80 @@
+package com.dawn.ai.config;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class AiConfigTest {
+
+    private final AiConfig aiConfig = new AiConfig();
+
+    @Test
+    void summarizeResponseBody_shouldCompressEmbeddingResponses() {
+        String body = """
+                {
+                  "object": "list",
+                  "data": [
+                    { "object": "embedding", "index": 0, "embedding": [0.1, 0.2, 0.3] },
+                    { "object": "embedding", "index": 1, "embedding": [0.4, 0.5, 0.6] }
+                  ],
+                  "model": "bge-m3",
+                  "usage": {
+                    "prompt_tokens": 12,
+                    "total_tokens": 12
+                  }
+                }
+                """;
+
+        String summary = ReflectionTestUtils.invokeMethod(aiConfig, "summarizeResponseBody", body);
+
+        assertThat(summary)
+                .contains("embeddings=2")
+                .contains("dimensions=3")
+                .contains("model=bge-m3")
+                .contains("promptTokens=12")
+                .contains("totalTokens=12");
+        assertThat(summary).doesNotContain("completionTokens=").doesNotContain("0.1").doesNotContain("[");
+    }
+
+    @Test
+    void formatDebugResponseBody_shouldOmitEmbeddingValues() {
+        String body = """
+                {
+                  "object": "list",
+                  "data": [
+                    { "object": "embedding", "index": 0, "embedding": [0.123, 0.456] }
+                  ],
+                  "model": "bge-m3"
+                }
+                """;
+
+        String detail = ReflectionTestUtils.invokeMethod(aiConfig, "formatDebugResponseBody", body);
+
+        assertThat(detail)
+                .contains("embeddings=1")
+                .contains("dimensions=2")
+                .contains("embeddingValues=<omitted>");
+        assertThat(detail).doesNotContain("0.123").doesNotContain("\"embedding\"");
+    }
+
+    @Test
+    void summarizeRequestBody_shouldIncludeEmbeddingInputSummary() {
+        String body = """
+                {
+                  "model": "bge-m3",
+                  "input": [
+                    "第一段文本",
+                    "第二段文本"
+                  ]
+                }
+                """;
+
+        String summary = ReflectionTestUtils.invokeMethod(aiConfig, "summarizeRequestBody", body);
+
+        assertThat(summary)
+                .contains("model=bge-m3")
+                .contains("inputs=2")
+                .contains("firstInput=「第一段文本」");
+    }
+}

--- a/src/test/java/com/dawn/ai/controller/RagControllerValidationTest.java
+++ b/src/test/java/com/dawn/ai/controller/RagControllerValidationTest.java
@@ -21,6 +21,7 @@ import org.springframework.validation.beanvalidation.MethodValidationPostProcess
 import java.util.Collections;
 import java.util.List;
 
+import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.containsString;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -52,7 +53,9 @@ class RagControllerValidationTest {
                         .param("query", "refund policy")
                         .param("topK", "21"))
                 .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.message").value(containsString("must be less than or equal to 20")));
+                .andExpect(jsonPath("$.message").value(allOf(
+                        containsString("topK"),
+                        containsString("20"))));
     }
 
     @Test
@@ -112,6 +115,29 @@ class RagControllerValidationTest {
 
         verify(documentTextExtractor).extract(any(), eq(DocumentType.TEXT));
         verify(ragService).ingest("refund policy content", "faq.txt", "billing");
+        }
+
+        @Test
+        void shouldIngestMultipartFileWithInferredPdfType() throws Exception {
+        MockMultipartFile file = new MockMultipartFile(
+            "file",
+            "novel.pdf",
+            "application/pdf",
+            "%PDF-1.4".getBytes()
+        );
+        when(documentTextExtractor.extract(any(), eq(DocumentType.PDF))).thenReturn("pdf extracted content");
+        when(ragService.ingest("pdf extracted content", "novel.pdf", "literature")).thenReturn("doc-pdf");
+
+        mockMvc.perform(multipart("/api/v1/rag/ingest")
+                .file(file)
+                .param("category", "literature"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.docId").value("doc-pdf"))
+            .andExpect(jsonPath("$.status").value("ingested"))
+            .andExpect(jsonPath("$.documentType").value("PDF"));
+
+        verify(documentTextExtractor).extract(any(), eq(DocumentType.PDF));
+        verify(ragService).ingest("pdf extracted content", "novel.pdf", "literature");
         }
 
         @Test

--- a/src/test/java/com/dawn/ai/controller/RagControllerValidationTest.java
+++ b/src/test/java/com/dawn/ai/controller/RagControllerValidationTest.java
@@ -2,6 +2,8 @@ package com.dawn.ai.controller;
 
 import com.dawn.ai.exception.ApiExceptionHandler;
 import com.dawn.ai.rag.RagService;
+import com.dawn.ai.rag.constants.DocumentType;
+import com.dawn.ai.rag.ingestion.DocumentTextExtractor;
 import com.dawn.ai.rag.retrieval.RetrievalRequest;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
@@ -12,6 +14,7 @@ import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.validation.beanvalidation.MethodValidationPostProcessor;
 
@@ -21,9 +24,12 @@ import java.util.List;
 import static org.hamcrest.Matchers.containsString;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -36,6 +42,9 @@ class RagControllerValidationTest {
 
     @MockBean
     private RagService ragService;
+
+    @MockBean
+    private DocumentTextExtractor documentTextExtractor;
 
     @Test
     void shouldRejectTopKGreaterThanTwenty() throws Exception {
@@ -81,6 +90,46 @@ class RagControllerValidationTest {
         assertThat(captor.getValue().getMetadataFilters()).containsEntry("source", List.of("pricing-doc"));
         assertThat(captor.getValue().getMetadataFilters()).containsEntry("category", List.of("billing"));
     }
+
+        @Test
+        void shouldIngestMultipartFileWithInferredTextType() throws Exception {
+        MockMultipartFile file = new MockMultipartFile(
+            "file",
+            "faq.txt",
+            "text/plain",
+            "refund policy content".getBytes()
+        );
+        when(documentTextExtractor.extract(any(), eq(DocumentType.TEXT))).thenReturn("refund policy content");
+        when(ragService.ingest("refund policy content", "faq.txt", "billing")).thenReturn("doc-123");
+
+        mockMvc.perform(multipart("/api/v1/rag/ingest")
+                .file(file)
+                .param("category", "billing"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.docId").value("doc-123"))
+            .andExpect(jsonPath("$.status").value("ingested"))
+            .andExpect(jsonPath("$.documentType").value("TEXT"));
+
+        verify(documentTextExtractor).extract(any(), eq(DocumentType.TEXT));
+        verify(ragService).ingest("refund policy content", "faq.txt", "billing");
+        }
+
+        @Test
+        void shouldRejectUnsupportedMultipartFileType() throws Exception {
+        MockMultipartFile file = new MockMultipartFile(
+            "file",
+            "data.bin",
+            "application/octet-stream",
+            "random".getBytes()
+        );
+
+        mockMvc.perform(multipart("/api/v1/rag/ingest").file(file))
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.message").value(containsString("Unsupported file format")));
+
+        verifyNoInteractions(documentTextExtractor);
+        verifyNoInteractions(ragService);
+        }
 
     @TestConfiguration
     static class ValidationConfig {

--- a/src/test/java/com/dawn/ai/rag/RagServiceIngestUuidTest.java
+++ b/src/test/java/com/dawn/ai/rag/RagServiceIngestUuidTest.java
@@ -1,0 +1,81 @@
+package com.dawn.ai.rag;
+
+import com.dawn.ai.config.AiAvailabilityChecker;
+import com.dawn.ai.rag.ingestion.OverlapTextSplitter;
+import com.dawn.ai.rag.retrieval.RetrievalRouter;
+import com.dawn.ai.rag.retrieval.fusion.ReciprocalRankFusion;
+import com.dawn.ai.rag.retrieval.rerank.HeuristicRetrievalReranker;
+import com.dawn.ai.rag.retrieval.sparse.SparseRetriever;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.ai.document.Document;
+import org.springframework.ai.vectorstore.VectorStore;
+
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class RagServiceIngestUuidTest {
+
+    @Mock
+    private VectorStore vectorStore;
+
+    @Mock
+    private AiAvailabilityChecker aiAvailabilityChecker;
+
+    @Mock
+    private SparseRetriever sparseRetriever;
+
+    private ExecutorService ragRetrievalExecutor;
+    private RagService ragService;
+
+    @BeforeEach
+    void setUp() {
+        ragRetrievalExecutor = Executors.newFixedThreadPool(2);
+        ragService = new RagService(
+                vectorStore,
+                new SimpleMeterRegistry(),
+                aiAvailabilityChecker,
+                new HeuristicRetrievalReranker(),
+                sparseRetriever,
+                new ReciprocalRankFusion(),
+                new RetrievalRouter(),
+                new OverlapTextSplitter(4, 2),
+                ragRetrievalExecutor);
+        ragService.initMetrics();
+    }
+
+    @AfterEach
+    void tearDown() {
+        ragRetrievalExecutor.shutdownNow();
+    }
+
+    @Test
+    @DisplayName("ingest: 多 chunk 写入时应使用 UUID 兼容的 chunk id，并保留 docId metadata")
+    void ingest_usesUuidCompatibleChunkIdsAndPreservesDocIdMetadata() {
+        String docId = ragService.ingest("one two three four five six seven", "pricing-doc", "billing");
+
+        ArgumentCaptor<List<Document>> captor = ArgumentCaptor.forClass(List.class);
+        verify(vectorStore).add(captor.capture());
+        assertThat(UUID.fromString(docId)).isNotNull();
+        assertThat(captor.getValue()).hasSize(3).allSatisfy(chunk -> {
+            assertThat(UUID.fromString(chunk.getId())).isNotNull();
+            assertThat(chunk.getMetadata()).containsEntry("docId", docId);
+            assertThat(chunk.getMetadata()).containsEntry("parentDocumentId", docId);
+            assertThat(chunk.getMetadata()).containsEntry("source", "pricing-doc");
+            assertThat(chunk.getMetadata()).containsEntry("category", "billing");
+        });
+    }
+}

--- a/src/test/java/com/dawn/ai/rag/ingestion/DocumentTextExtractorPdfTest.java
+++ b/src/test/java/com/dawn/ai/rag/ingestion/DocumentTextExtractorPdfTest.java
@@ -1,0 +1,43 @@
+package com.dawn.ai.rag.ingestion;
+
+import com.dawn.ai.rag.constants.DocumentType;
+import org.apache.pdfbox.pdmodel.PDDocument;
+import org.apache.pdfbox.pdmodel.PDPage;
+import org.apache.pdfbox.pdmodel.PDPageContentStream;
+import org.apache.pdfbox.pdmodel.font.PDType1Font;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockMultipartFile;
+
+import java.io.ByteArrayOutputStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class DocumentTextExtractorPdfTest {
+
+    @Test
+    void shouldExtractTextFromPdf() throws Exception {
+        byte[] pdfBytes = createPdf("sample pdf content");
+        MockMultipartFile file = new MockMultipartFile("file", "sample.pdf", "application/pdf", pdfBytes);
+
+        String text = new DocumentTextExtractor().extract(file, DocumentType.PDF);
+
+        assertThat(text).contains("sample pdf content");
+    }
+
+    private byte[] createPdf(String text) throws Exception {
+        try (PDDocument document = new PDDocument();
+             ByteArrayOutputStream outputStream = new ByteArrayOutputStream()) {
+            PDPage page = new PDPage();
+            document.addPage(page);
+            try (PDPageContentStream contentStream = new PDPageContentStream(document, page)) {
+                contentStream.beginText();
+                contentStream.setFont(PDType1Font.HELVETICA, 12);
+                contentStream.newLineAtOffset(50, 700);
+                contentStream.showText(text);
+                contentStream.endText();
+            }
+            document.save(outputStream);
+            return outputStream.toByteArray();
+        }
+    }
+}

--- a/src/test/java/com/dawn/ai/rag/ingestion/OverlapTextSplitterTest.java
+++ b/src/test/java/com/dawn/ai/rag/ingestion/OverlapTextSplitterTest.java
@@ -6,25 +6,26 @@ import org.springframework.ai.document.Document;
 
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 class OverlapTextSplitterTest {
 
     @Test
-    @DisplayName("apply: 按 chunkSize 和 overlap 生成重叠 chunks")
+    @DisplayName("apply: 按 token 窗口切分并保留 overlap")
     void apply_createsOverlappingChunks() {
-        OverlapTextSplitter splitter = new OverlapTextSplitter(4, 2);
-        Document document = new Document("doc-1", "one two three four five six seven", Map.of("source", "pricing"));
+    OverlapTextSplitter splitter = new OverlapTextSplitter(4, 2);
+    Document document = new Document("doc-1", "one two three four five six seven", Map.of("source", "pricing"));
 
-        List<Document> chunks = splitter.apply(List.of(document));
+    List<Document> chunks = splitter.apply(List.of(document));
 
-        assertThat(chunks).extracting(Document::getText)
-                .containsExactly(
-                        "one two three four",
-                        "three four five six",
-                        "five six seven"
-                );
+    assertThat(chunks).extracting(Document::getText)
+        .containsExactly(
+            "one two three four",
+            "three four five six",
+            "five six seven"
+        );
     }
 
     @Test
@@ -33,7 +34,8 @@ class OverlapTextSplitterTest {
         OverlapTextSplitter splitter = new OverlapTextSplitter(3, 1);
         Document document = new Document("doc-9", "alpha beta gamma delta epsilon", Map.of(
                 "source", "kb",
-                "category", "billing"
+                "category", "billing",
+                "docId", "doc-9"
         ));
 
         List<Document> chunks = splitter.apply(List.of(document));
@@ -42,10 +44,49 @@ class OverlapTextSplitterTest {
         assertThat(chunks).allSatisfy(chunk -> {
             assertThat(chunk.getMetadata()).containsEntry("source", "kb");
             assertThat(chunk.getMetadata()).containsEntry("category", "billing");
+            assertThat(chunk.getMetadata()).containsEntry("docId", "doc-9");
             assertThat(chunk.getMetadata()).containsEntry("parentDocumentId", "doc-9");
             assertThat(chunk.getMetadata()).containsEntry("chunkCount", 2);
         });
         assertThat(chunks.get(0).getMetadata()).containsEntry("chunkIndex", 0);
         assertThat(chunks.get(1).getMetadata()).containsEntry("chunkIndex", 1);
+    }
+
+    @Test
+    @DisplayName("apply: 多 chunk 文档生成 PGVector 兼容的 UUID chunk id")
+    void apply_generatesUuidCompatibleChunkIdsForMultipleChunks() {
+        OverlapTextSplitter splitter = new OverlapTextSplitter(4, 2);
+        String parentId = UUID.randomUUID().toString();
+        Document document = new Document(parentId, "one two three four five six seven", Map.of("docId", parentId));
+
+        List<Document> chunks = splitter.apply(List.of(document));
+
+        assertThat(chunks).hasSize(3);
+        assertThat(chunks).extracting(Document::getId).doesNotHaveDuplicates();
+        assertThat(chunks).allSatisfy(chunk -> {
+            assertThat(UUID.fromString(chunk.getId())).isNotNull();
+            assertThat(chunk.getMetadata()).containsEntry("docId", parentId);
+            assertThat(chunk.getMetadata()).containsEntry("parentDocumentId", parentId);
+        });
+    }
+
+    @Test
+    @DisplayName("apply: 优先在标点边界截断，避免句子中间硬切")
+    void apply_prefersPunctuationBoundaries() {
+        OverlapTextSplitter splitter = new OverlapTextSplitter(
+                12,
+                2);
+        Document document = new Document(
+                "doc-2",
+                "alpha beta gamma delta epsilon. zeta eta theta iota kappa lambda mu nu xi omicron.",
+                Map.of("source", "kb"));
+
+        List<Document> chunks = splitter.apply(List.of(document));
+
+        assertThat(chunks).hasSizeGreaterThan(1);
+        assertThat(chunks.get(0).getText()).endsWith("epsilon.");
+        assertThat(chunks.get(1).getText()).contains("zeta eta theta");
+        assertThat(chunks).extracting(Document::getText)
+                .allMatch(text -> !text.isBlank());
     }
 }


### PR DESCRIPTION
为 RAG pipeline 新增文件上传 ingest 能力，并将原有基于空格分词的文本切分器替换为支持 token 计数与标点边界感知的实现。

## 变更内容

### 多部分文件 Ingest（`/api/v1/rag/ingest` multipart）
- 新增 `DocumentType` 枚举（TEXT / PDF / WORD / EXCEL）以及 `DocumentTextExtractor` 组件——二进制格式通过 Apache Tika 解析，文本文件直接以 UTF-8 读取。
- 将原有 `/ingest` 接口拆分为两个重载映射：JSON 版本保持不变，新增 `multipart/form-data` 版本。multipart 版本在调用方未显式传入文档类型时，会根据文件名和 Content-Type 自动推断。
- 在 `ApiExceptionHandler` 中补充 `IllegalArgumentException` 处理器，将校验错误以 HTTP 400 返回。
- 在 `application.yml` 中配置 Spring multipart 上传限制：单文件最大 10 MB，单次请求最大 100 MB。
- 将前端文件上传区从 "coming soon" 占位实现改为完整功能：支持拖拽上传、点击选文件、Source / Category / DocumentType 表单项、上传按钮及结果展示。

### Token 感知的 `OverlapTextSplitter`
- 用 `CL100K_BASE` 编码替换原有空格分词，token 计数与 GPT-4 / text-embedding-ada-002 保持一致。
- 当最后一个标点符号位置超过 `minChunkSizeChars` 时，分块优先在标点边界（`.`、`?`、`!`、`\n`）处截断，避免句子中间硬切。
- Chunk ID 改用 `UUID.nameUUIDFromBytes`（UUID v3，源字符串为 `"<docId>#chunk-<n>"`），替换原有字符串拼接方式，兼容 PGVector 的 UUID 列类型。
- `docId` 随 `parentDocumentId` 一同写入 chunk metadata，便于下游追溯。
- 新增构造参数：`minChunkSizeChars`（默认 350）、`minChunkLengthToEmbed`（默认 5）、`maxNumChunks`（默认 10 000）。

## 新增测试
- `AiConfigTest` — embedding 响应摘要与压缩逻辑
- `RagControllerValidationTest` — multipart 上传正常路径（text、PDF）及不支持格式的拒绝校验
- `RagServiceIngestUuidTest` — 验证 UUID 兼容的 chunk ID 生成及 `docId` metadata 端到端传播
- `DocumentTextExtractorPdfTest` — 通过 PDFBox 生成 PDF 并经 Tika 解析的集成测试
- `OverlapTextSplitterTest` — UUID chunk ID 和标点边界切分的新用例