### PR TITLE
feat(observability): 新增 AI 交互日志系统及跨线程 sessionId 传播机制

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,3 +8,11 @@ EMBEDDING_BASE_URL=http://host.docker.internal:8000
 EMBEDDING_API_KEY=2486
 EMBEDDING_DIMENSIONS=1024
 EMBEDDING_MODEL=bge-m3-mlx-fp16
+
+# qwen
+BASE_URL=https://dashscope.aliyuncs.com/compatible-mode/
+CHAT_MODEL=qwen3.6-plus
+
+# openrouter
+BASE_URL=https://openrouter.ai/api
+CHAT_MODEL=

--- a/docs/Summary.md
+++ b/docs/Summary.md
@@ -1,4 +1,7 @@
-
+---
+updated: 2026-05-10 22:23
+---
+# Tech
 ## Tech points
   
   - 3 层记忆体系：Working(Redis) → Summary(pgvector) → Long-term(向量反思) — 跨会话持久记忆
@@ -7,7 +10,58 @@
   - 用户画像注入：User profile 自动注入 system prompt，实现个性化
   - 完整可观测：Prometheus + Grafana，token 成本追踪
 
-## 应用方向
+## ReAct
+
+项目要点：
+
+学习要点：
+- ReAct 适合用在局部决策场景，而不是整个系统。**大多数场景，整体流程是确定的**，适合用 workflow 来保证稳定性。针对某些局部节点（如果需要根据当前上下文动态决定是否调用工具、调用哪个工具、是否进行多轮推理，这时候可以引入 ReAct 来增强灵活性），使用 ReAct 来处理不确定性，保证稳定性和灵活性之间取得平衡。
+
+## Spring 
+
+### [SSE] - ThreadLocal 跨线程传播模式
+
+- 详细参考:  [[#ThreadLocal 跨线程传播模式详解]]
+> [!NOTE]
+> 
+> - Servlet/任意线程 → Reactor 调度器线程: 通过 Reactor Context + Micrometer Hook来处理
+> - 任意线程 -> 自定义 ExecutorService：通过使用装饰器 wrap 或手动快照来解决
+> 
+
+SSE 模型下，易出现多线程的共享问题，这里处理多线程 threadlocal 数据共享问题：
+- Reactor 模型：通过项目中自定义 ApplicationRunner bean，保持时序，实现跨线程的访问。覆盖的是 `Servlet/任意线程 → Reactor 调度器线程` 这个场景。
+`ApplicationRunner` 的唯一目的是**时序控制**：
+```
+所有 Bean 初始化完成
+所有 WebClient / RestClient 基础设施就绪
+↓
+ApplicationRunner.run()
+    registerThreadLocalAccessor(...)   ← 注册哪些 ThreadLocal
+    Hooks.enableAutomaticContextPropagation()  ← 开启 Reactor 全局 Hook
+↓
+第一个真实业务请求进来
+``` 
+
+在这个窗口注册，既能覆盖所有后续的 Reactor pipeline，又能享受完整的 Spring 上下文（条件判断、日志、依赖注入）。
+- 
+
+### [SSE] - Spring WebMVC(阻塞 io 模型) + SseEmitter
+
+- 详细参考：[[#SseEmitter 与 Spring WebFlux 的核心区别]]
+
+项目使用 Spring webmvc 框架，属于阻塞 io 模型，基于 servlet api。对于基于非阻塞模型的 Spring Webflux 模型，有几点不同。
+
+| 维度          | SseEmitter (Spring MVC)      | Spring WebFlux (Flux SSE)       |
+| ----------- | ---------------------------- | ------------------------------- |
+| **并发模型**    | 阻塞/异步线程池，每个长连接占用资源较多         | 非阻塞 Reactive，背压（backpressure）支持 |
+| **资源消耗**    | 高并发时线程数容易成为瓶颈                | 极低线程数（几十个线程可支撑数万连接）             |
+| **编程风格**    | 命令式（Imperative），易理解          | 函数式+响应式，学习曲线较陡                  |
+| **错误/超时处理** | 需手动管理 complete、timeout、error | Reactor 自动处理，生命周期更优雅            |
+| **性能**      | 适合中等并发                       | 极高吞吐量、高并发场景首选                   |
+| **集成难度**    | 简单，直接用注解控制器                  | 需要理解 Mono/Flux，响应式数据源更佳         |
+| **适用场景**    | 已有 MVC 项目、简单实时推送、中低并发        | 新项目、高并发微服务、流式数据处理               |
+
+# 应用方向
 
 个人学习追踪助手：上传技术书/笔记/论文等   → 问问题 → AI 追踪"你学了什么、还不会什么"
 
@@ -26,7 +80,9 @@
 Topic 作纯 Metadata 标签（最轻）, 不新建 Topic 实体，仅在现有 RAG 的 metadata 里加 topicId 字段。KnowledgeSearchTool 带 topicId 过滤即可。
 Gap analysis 完全依赖 LLM 推理："在这个 topic 的文档里搜索 X，没结果就是盲点"。
 
-## Reference
+# Reference
+
+### 应用方向
 
 三个推荐方向
 
@@ -104,3 +160,154 @@ Gap analysis 完全依赖 LLM 推理："在这个 topic 的文档里搜索 X，�
 
   优点：把现有所有技术栈都激活，工具链设计有层次，最能体现 Agent 架构能力。
   弱点：需要新增概念索引的数据结构，工程量中等。
+
+### ThreadLocal 跨线程传播模式详解
+#### 问题本质
+
+`ThreadLocal` 是线程隔离的，这既是它的优点（天然线程安全），也是它的限制——当任务从线程 A 提交到线程 B 执行时，B 上读不到 A 设置的值。
+
+```
+Thread A: ThreadLocal.set("value")
+    └── executor.submit(task)
+            └── Thread B: ThreadLocal.get() → null  ❌
+```
+
+在异步/响应式架构中，一次业务请求可能跨越：
+- Servlet 线程 → 自定义线程池
+- Servlet 线程 → Reactor 调度器（`boundedElastic` / `parallel`）
+- Reactor operator → operator（`publishOn` 切换调度器）
+
+---
+
+#### 三种传播手段
+
+##### 1. 手动快照传递（适合简单异步场景）
+
+在**提交侧**捕获值，用闭包包裹任务：
+
+```java
+String captured = threadLocal.get();   // 提交线程抓快照
+executor.submit(() -> {
+    String prev = threadLocal.get();
+    threadLocal.set(captured);         // 工作线程恢复
+    try { task.run(); }
+    finally {
+        if (prev == null) threadLocal.remove();
+        else threadLocal.set(prev);    // 恢复原值，防止线程池线程污染
+    }
+});
+```
+
+关键点：`finally` 里必须恢复而不是直接 `remove()`，因为线程池线程可能本身就有值。
+
+##### 2. ExecutorService 装饰器（适合线程池统一管理） - 
+
+避免每次提交都手动 wrap，用装饰器模式统一拦截：
+
+```java
+class ContextAwareExecutor implements ExecutorService {
+    public Future<?> submit(Runnable task) {
+        return delegate.submit(Context.wrap(task));  // 统一入口
+    }
+    // invokeAll / invokeAny 同样处理...
+}
+```
+
+好处：调用方无感知，只需将线程池替换为装饰版。
+
+##### 3. Micrometer Context Propagation（适合 Reactor 响应式管道）
+
+Reactor 的调度器切换无法用上述方式拦截。Micrometer 提供了标准 SPI：
+
+```java
+// 1. 声明哪个 ThreadLocal 需要传播
+class MyAccessor implements ThreadLocalAccessor<String> {
+    public String getValue() { return threadLocal.get(); }
+    public void setValue(String v) { threadLocal.set(v); }
+    public void setValue() { threadLocal.remove(); }    // 无值时的清理
+}
+
+// 2. 注册 + 开启
+ContextRegistry.getInstance().registerThreadLocalAccessor(new MyAccessor());
+Hooks.enableAutomaticContextPropagation();  // 告诉 Reactor 接管所有已注册的 ThreadLocal
+```
+
+开启后，Reactor 在每次 `publishOn` / `subscribeOn` 切换线程前，自动将所有注册的 ThreadLocal 值保存到 Reactor Context，切换后从 Context 恢复到新线程。
+
+---
+
+#### 三者对比
+
+| 方式                    | 适用场景       | 侵入性     | 覆盖范围           |
+| --------------------- | ---------- | ------- | -------------- |
+| 手动 `wrap`             | 少量一次性提交    | 高（每次手写） | 仅包裹的任务         |
+| `ExecutorService` 装饰器 | 自定义线程池     | 低（换一次池） | 该池所有任务         |
+| Micrometer Accessor   | Reactor 管道 | 低（注册一次） | 所有 operator 切换 |
+
+---
+
+#### 两个容易忽略的细节
+
+**引用传播 vs 值传播**  
+如果 ThreadLocal 存的是**可变对象的引用**（如 `List`），传播后所有线程共享同一对象，修改互相可见——这可能是特性（如聚合多线程结果），也可能是 bug。如果存的是**不可变值**（如 `String`），则每次传播是独立快照，互不影响。
+
+**additivity=false 的日志隔离**  
+命名 Logger + `additivity="false"` 是 logback 中将特定日志流路由到独立文件的标准做法，与上下文传播无关，但常配合使用——传播保证"写谁的"，独立 Logger 保证"写到哪"。
+
+### SseEmitter 与 Spring WebFlux 的核心区别
+
+从原始需求出发：两者都**可以实现 Server-Sent Events (SSE)**，即服务器单向实时推送数据给客户端（如实时通知、监控、聊天等）。但它们解决问题的**底层模型和适用场景完全不同**。
+
+#### 1. 所属框架与编程模型
+- **SseEmitter**：属于 **Spring MVC**（基于 Servlet 容器，如 Tomcat）。它是传统的**阻塞/线程池模型**的扩展。
+  - 核心是 `SseEmitter` 类（Spring 4.2 引入），继承自 `ResponseBodyEmitter`。
+  - 每个连接通常占用一个线程（或通过异步线程池管理），连接保持打开。
+  - 适合**请求-响应**风格的同步思维开发者。
+- **Spring WebFlux**：Spring 5 引入的**响应式 Web 框架**，基于 Reactive Streams + Netty（默认）或 Undertow。
+  - 使用 `Flux<ServerSentEvent<T>>` 或 `Flux<T>` 返回 SSE 流。
+  - **非阻塞、事件驱动**模型，少量线程即可处理大量并发连接（通过 Reactor 调度器）。
+
+#### 2. 关键技术差异对比
+| 维度          | SseEmitter (Spring MVC)                  | Spring WebFlux (Flux SSE)                  |
+|---------------|------------------------------------------|--------------------------------------------|
+| **并发模型** | 阻塞/异步线程池，每个长连接占用资源较多 | 非阻塞 Reactive，背压（backpressure）支持 |
+| **资源消耗** | 高并发时线程数容易成为瓶颈               | 极低线程数（几十个线程可支撑数万连接）     |
+| **编程风格** | 命令式（Imperative），易理解             | 函数式+响应式，学习曲线较陡                 |
+| **错误/超时处理** | 需手动管理 complete、timeout、error     | Reactor 自动处理，生命周期更优雅           |
+| **性能**      | 适合中等并发                             | 极高吞吐量、高并发场景首选                 |
+| **集成难度**  | 简单，直接用注解控制器                   | 需要理解 Mono/Flux，响应式数据源更佳       |
+| **适用场景**  | 已有 MVC 项目、简单实时推送、中低并发   | 新项目、高并发微服务、流式数据处理         |
+
+#### 3. 代码风格示例（概念对比）
+**SseEmitter 示例**（MVC）：
+```java
+@GetMapping("/sse")
+public SseEmitter handleSse() {
+    SseEmitter emitter = new SseEmitter(0L); // 超时时间
+    // 异步线程推送
+    executor.execute(() -> {
+        try {
+            emitter.send("数据");
+        } catch (Exception e) {
+            emitter.completeWithError(e);
+        }
+    });
+    return emitter;
+}
+```
+
+**WebFlux 示例**：
+```java
+@GetMapping(value = "/sse", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
+public Flux<ServerSentEvent<String>> handleSse() {
+    return Flux.interval(Duration.ofSeconds(1))
+               .map(i -> ServerSentEvent.<String>builder()
+                   .data("数据 " + i)
+                   .build());
+}
+```
+
+#### 4. 选型建议（从需求出发）
+- 如果你的项目已经是 **Spring MVC** 栈，且并发不高、团队对响应式不熟悉 → 优先用 **SseEmitter**，改动最小。
+- 如果追求**高并发、低延迟、资源利用率**，或项目已计划响应式 → 强烈推荐 **Spring WebFlux**。
+- 混合使用：WebFlux 项目里也可以注入 SseEmitter，但不推荐（破坏响应式优势）。

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -1,0 +1,9 @@
+---
+updated: 2026-05-07 22:46
+---
+1. System Prompt 动态组装 #issue22
+2. Multi-Agent #issue28
+3. RAG 中文检索优化 + 引入 Hyde 召回率优化 #issue36
+4. 引入 Agent 评估系统 #issue26
+5. 支持 Skill 和 MCP 协议 #issue25
+6. 支持更多的 tools 

--- a/src/main/java/com/dawn/ai/config/AgentConfig.java
+++ b/src/main/java/com/dawn/ai/config/AgentConfig.java
@@ -55,7 +55,7 @@ public class AgentConfig {
 
     @Bean(name = "ragRetrievalExecutor", destroyMethod = "shutdown")
     public ExecutorService ragRetrievalExecutor() {
-        return new ThreadPoolExecutor(
+        ThreadPoolExecutor pool = new ThreadPoolExecutor(
                 4, 16,
                 60L, TimeUnit.SECONDS,
                 new LinkedBlockingQueue<>(128),
@@ -66,36 +66,38 @@ public class AgentConfig {
                 },
                 new ThreadPoolExecutor.CallerRunsPolicy()
         );
+        return new SessionAwareExecutor(pool);
     }
 
     /**
-     * Enables Micrometer context propagation for the reactive (Reactor) pipeline.
+     * 为响应式（Reactor）管道启用 Micrometer 上下文传播。
      *
-     * <p>Without this, {@link com.dawn.ai.agent.trace.StepCollector}'s ThreadLocal state
-     * is invisible to Reactor Netty worker threads that execute Spring AI tool callbacks
-     * during streaming, causing NPEs and silent tool failures.
+     * <p>若不启用，{@link com.dawn.ai.agent.trace.StepCollector} 的 ThreadLocal 状态
+     * 对 Reactor Netty 工作线程不可见——而 Spring AI 的 tool callback 在流式响应期间
+     * 正是运行在这些线程上，从而导致 NPE 和 tool 调用静默失败。
      *
-     * <p>How it works:
+     * <p>工作原理：
      * <ol>
-     *   <li>We register {@link StepCollectorContextAccessor} with Micrometer's
-     *       {@link ContextRegistry} so Micrometer knows which ThreadLocal to capture.</li>
-     *   <li>{@link Hooks#enableAutomaticContextPropagation()} tells Reactor to capture all
-     *       registered ThreadLocals into the reactive pipeline context at subscribe time,
-     *       and restore them before every operator — even across thread hops.</li>
-     *   <li>Since {@link com.dawn.ai.agent.trace.StepCollectorContext} is propagated by
-     *       <em>reference</em>, all threads share the same mutable state object, making
-     *       step counting and collection correct across threads.</li>
+     *   <li>将 {@link StepCollectorContextAccessor} 注册到 Micrometer 的
+     *       {@link ContextRegistry}，告知 Micrometer 哪些 ThreadLocal 需要被捕获。</li>
+     *   <li>{@link Hooks#enableAutomaticContextPropagation()} 指示 Reactor 在订阅时
+     *       将所有已注册的 ThreadLocal 捕获到响应式管道上下文中，并在每个操作符执行前
+     *       自动恢复——即使发生了线程切换。</li>
+     *   <li>由于 {@link com.dawn.ai.agent.trace.StepCollectorContext} 是按
+     *       <em>引用</em> 传播的，所有线程共享同一个可变状态对象，从而保证跨线程的
+     *       步骤计数与收集结果正确。</li>
      * </ol>
      */
     @Bean
     public ApplicationRunner enableReactorContextPropagation() {
         return args -> {
-            // 告诉 Micrometer：存在一个 ThreadLocal 需要传播
+            // 告诉 Micrometer：存在一些 ThreadLocal 需要传播
             ContextRegistry.getInstance()
-                    .registerThreadLocalAccessor(new StepCollectorContextAccessor());
+                    .registerThreadLocalAccessor(new StepCollectorContextAccessor())
+                    .registerThreadLocalAccessor(new AiInteractionContextAccessor());
             // 告诉 Reactor：每次切换线程前自动调用所有 Accessor 的 set/restore
             Hooks.enableAutomaticContextPropagation();
-            log.info("[AgentConfig] Reactor automatic context propagation enabled (StepCollector)");
+            log.info("[AgentConfig] Reactor automatic context propagation enabled (StepCollector, AiInteractionContext)");
         };
     }
 }

--- a/src/main/java/com/dawn/ai/config/AiConfig.java
+++ b/src/main/java/com/dawn/ai/config/AiConfig.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Timer;
+import org.reactivestreams.Publisher;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.ai.chat.client.ChatClient;
@@ -13,19 +14,27 @@ import org.springframework.boot.ApplicationRunner;
 import org.springframework.context.annotation.Primary;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.io.buffer.DataBuffer;
+import org.springframework.core.io.buffer.DataBufferUtils;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.client.ClientHttpRequestInterceptor;
 import org.springframework.http.client.BufferingClientHttpRequestFactory;
 import org.springframework.http.client.ClientHttpResponse;
 import org.springframework.http.client.SimpleClientHttpRequestFactory;
+import org.springframework.http.client.reactive.ClientHttpRequest;
+import org.springframework.http.client.reactive.ClientHttpRequestDecorator;
+import org.springframework.web.reactive.function.BodyInserter;
 import org.springframework.web.reactive.function.client.ClientRequest;
 import org.springframework.web.reactive.function.client.ExchangeFilterFunction;
 import org.springframework.web.reactive.function.client.ExchangeStrategies;
 import org.springframework.web.reactive.function.client.WebClient;
 import org.springframework.util.StreamUtils;
 import org.springframework.web.client.RestClient;
+import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
+import java.io.ByteArrayOutputStream;
+import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 
@@ -69,12 +78,17 @@ public class AiConfig {
 
     @Bean
     @Primary
-    public RestClient.Builder openAiRestClientBuilder() {
+    public RestClient.Builder openAiRestClientBuilder(AiInteractionLogger aiInteractionLogger) {
         ClientHttpRequestInterceptor loggingInterceptor = (request, body, execution) -> {
             String reqBodyText = new String(body, StandardCharsets.UTF_8);
-            log.info("[AI HTTP] --> {} {} | {}", request.getMethod(), request.getURI(), summarizeRequestBody(reqBodyText));
+            String sessionId = AiInteractionContext.getSessionId();
 
+            log.info("[AI HTTP] --> {} {} | {}", request.getMethod(), request.getURI(), summarizeRequestBody(reqBodyText));
+            aiInteractionLogger.logRequest(sessionId, request.getMethod().name(), request.getURI().toString(), reqBodyText);
+
+            long start = System.currentTimeMillis();
             ClientHttpResponse response = execution.execute(request, body);
+            long latency = System.currentTimeMillis() - start;
 
             byte[] responseBody = StreamUtils.copyToByteArray(response.getBody());
             String responseBodyText = new String(responseBody, resolveCharset(response.getHeaders()));
@@ -84,6 +98,7 @@ public class AiConfig {
             if (log.isDebugEnabled()) {
                 log.debug("[AI HTTP] <-- response body detail:\n{}", formatDebugResponseBody(responseBodyText));
             }
+            aiInteractionLogger.logResponse(sessionId, response.getStatusCode().value(), responseBodyText, latency);
 
             return response;
         };
@@ -95,15 +110,15 @@ public class AiConfig {
 
     @Bean
     @Primary
-    public WebClient.Builder openAiWebClientBuilder() {
+    public WebClient.Builder openAiWebClientBuilder(AiInteractionLogger aiInteractionLogger) {
         ExchangeStrategies strategies = ExchangeStrategies.builder()
                 .codecs(configurer -> configurer.defaultCodecs().maxInMemorySize(16 * 1024 * 1024))
                 .build();
 
         return WebClient.builder()
                 .exchangeStrategies(strategies)
-                .filter(logStreamingRequest())
-                .filter(logStreamingResponse());
+                .filter(logStreamingRequest(aiInteractionLogger))
+                .filter(logStreamingResponse(aiInteractionLogger));
     }
 
     @Bean
@@ -223,20 +238,85 @@ public class AiConfig {
         }
     }
 
-    private ExchangeFilterFunction logStreamingRequest() {
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    private ExchangeFilterFunction logStreamingRequest(AiInteractionLogger aiInteractionLogger) {
         return ExchangeFilterFunction.ofRequestProcessor(request -> {
             log.info("[AI STREAM HTTP] --> {} {} | headers={}",
                     request.method(), request.url(), sanitizeHeaders(request));
-            return Mono.just(request);
+            String sessionId = AiInteractionContext.getSessionId();
+            String url = request.url().toString();
+            String method = request.method().name();
+            BodyInserter<?, ? super ClientHttpRequest> originalInserter = request.body();
+
+            BodyInserter wrappedInserter = (BodyInserter<Object, ClientHttpRequest>) (message, context) -> {
+                BodyCapturingHttpRequest capturing = new BodyCapturingHttpRequest(message);
+                return ((BodyInserter) originalInserter).insert(capturing, context)
+                        .doFinally(signal -> {
+                            try {
+                                aiInteractionLogger.logRequest(sessionId, method, url, capturing.getCapturedBody());
+                            } catch (Exception ex) {
+                                log.warn("[AI STREAM HTTP] failed to log captured request body: {}", ex.getMessage());
+                            }
+                        });
+            };
+
+            return Mono.just(ClientRequest.from(request).body(wrappedInserter).build());
         });
     }
 
-    private ExchangeFilterFunction logStreamingResponse() {
+    private ExchangeFilterFunction logStreamingResponse(AiInteractionLogger aiInteractionLogger) {
         return ExchangeFilterFunction.ofResponseProcessor(response -> {
             log.info("[AI STREAM HTTP] <-- status={} | contentType={}",
                     response.statusCode(), response.headers().contentType().orElse(null));
+            // SSE response body is too large/streamy to capture fully here.
+            // ChatService writes a LOGICAL response with the aggregated answer when streaming completes.
             return Mono.just(response);
         });
+    }
+
+    /**
+     * Reactive client request wrapper that buffers the outgoing body bytes so we can
+     * record them to the AI interaction log. Uses {@link DataBufferUtils#join} to safely
+     * combine all chunks into a single buffer regardless of underlying DataBuffer impl.
+     */
+    private static final class BodyCapturingHttpRequest extends ClientHttpRequestDecorator {
+        private final ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+
+        BodyCapturingHttpRequest(ClientHttpRequest delegate) {
+            super(delegate);
+        }
+
+        @Override
+        public Mono<Void> writeWith(Publisher<? extends DataBuffer> body) {
+            return DataBufferUtils.join(Flux.from(body)).flatMap(joined -> {
+                copyToBuffer(joined);
+                return super.writeWith(Mono.just(joined));
+            });
+        }
+
+        @Override
+        public Mono<Void> writeAndFlushWith(Publisher<? extends Publisher<? extends DataBuffer>> body) {
+            return DataBufferUtils.join(Flux.from(body).flatMap(Flux::from)).flatMap(joined -> {
+                copyToBuffer(joined);
+                return super.writeWith(Mono.just(joined));
+            });
+        }
+
+        private void copyToBuffer(DataBuffer dataBuffer) {
+            try {
+                int n = dataBuffer.readableByteCount();
+                if (n <= 0) return;
+                byte[] copy = new byte[n];
+                ByteBuffer view = dataBuffer.toByteBuffer();
+                view.get(copy);
+                buffer.write(copy, 0, n);
+            } catch (Exception ignored) {
+            }
+        }
+
+        String getCapturedBody() {
+            return buffer.toString(StandardCharsets.UTF_8);
+        }
     }
 
     private String snippet(String value) {

--- a/src/main/java/com/dawn/ai/config/AiInteractionContext.java
+++ b/src/main/java/com/dawn/ai/config/AiInteractionContext.java
@@ -1,0 +1,67 @@
+package com.dawn.ai.config;
+
+import java.util.concurrent.Callable;
+
+/**
+ * Carries the current chat sessionId on the executing thread so low-level HTTP
+ * interceptors can attribute Spring AI request/response bodies to a session.
+ */
+public final class AiInteractionContext {
+
+    private static final ThreadLocal<String> SESSION_ID = new ThreadLocal<>();
+
+    private AiInteractionContext() {
+    }
+
+    public static void setSessionId(String sessionId) {
+        if (sessionId == null || sessionId.isBlank()) {
+            SESSION_ID.remove();
+            return;
+        }
+        SESSION_ID.set(sessionId);
+    }
+
+    public static String getSessionId() {
+        return SESSION_ID.get();
+    }
+
+    public static void clear() {
+        SESSION_ID.remove();
+    }
+
+    /**
+     * Wraps a Runnable so the captured sessionId is restored on the worker thread
+     * before {@code task} runs, then cleared afterwards. Use when submitting work
+     * that needs to attribute downstream LLM/embedding calls back to the originating
+     * chat session.
+     */
+    public static Runnable wrap(Runnable task) {
+        String captured = SESSION_ID.get();
+        if (captured == null) return task;
+        return () -> {
+            String prev = SESSION_ID.get();
+            SESSION_ID.set(captured);
+            try {
+                task.run();
+            } finally {
+                if (prev == null) SESSION_ID.remove();
+                else SESSION_ID.set(prev);
+            }
+        };
+    }
+
+    public static <T> Callable<T> wrap(Callable<T> task) {
+        String captured = SESSION_ID.get();
+        if (captured == null) return task;
+        return () -> {
+            String prev = SESSION_ID.get();
+            SESSION_ID.set(captured);
+            try {
+                return task.call();
+            } finally {
+                if (prev == null) SESSION_ID.remove();
+                else SESSION_ID.set(prev);
+            }
+        };
+    }
+}

--- a/src/main/java/com/dawn/ai/config/AiInteractionContextAccessor.java
+++ b/src/main/java/com/dawn/ai/config/AiInteractionContextAccessor.java
@@ -1,0 +1,37 @@
+package com.dawn.ai.config;
+
+import io.micrometer.context.ThreadLocalAccessor;
+
+/**
+ * Bridges Micrometer context propagation with {@link AiInteractionContext} so the
+ * sessionId follows reactive pipelines across worker threads (e.g. Reactor's
+ * {@code boundedElastic} scheduler used by Spring AI tool callbacks). Without this,
+ * embedding/tool calls running on a different thread would log to the
+ * {@code "no-session"} bucket and never surface in the per-session UI.
+ *
+ * <p>Registered in {@link AgentConfig#enableReactorContextPropagation()}.
+ */
+public class AiInteractionContextAccessor implements ThreadLocalAccessor<String> {
+
+    public static final String KEY = "dawn.ai.interactionSession";
+
+    @Override
+    public Object key() {
+        return KEY;
+    }
+
+    @Override
+    public String getValue() {
+        return AiInteractionContext.getSessionId();
+    }
+
+    @Override
+    public void setValue(String value) {
+        AiInteractionContext.setSessionId(value);
+    }
+
+    @Override
+    public void setValue() {
+        AiInteractionContext.clear();
+    }
+}

--- a/src/main/java/com/dawn/ai/config/AiInteractionLogger.java
+++ b/src/main/java/com/dawn/ai/config/AiInteractionLogger.java
@@ -1,0 +1,107 @@
+package com.dawn.ai.config;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import lombok.Builder;
+import lombok.Value;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import java.time.Instant;
+import java.util.UUID;
+
+/**
+ * Records every outgoing AI HTTP request and incoming response to the
+ * {@code AI_INTERACTION} file logger (rolling, see logback-spring.xml).
+ *
+ * <p>The frontend reads the resulting log file via
+ * {@link com.dawn.ai.controller.AiInteractionController#tailLog}.
+ */
+@Component
+public class AiInteractionLogger {
+
+    private static final Logger FILE_LOG = LoggerFactory.getLogger("AI_INTERACTION");
+    private static final int MAX_BODY_CHARS_IN_FILE = 12_000;
+    private static final String UNKNOWN_SESSION = "no-session";
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    public void logRequest(String sessionId, String method, String url, String body) {
+        write(Entry.builder()
+                .id(UUID.randomUUID().toString())
+                .timestamp(Instant.now().toString())
+                .sessionId(normalize(sessionId))
+                .direction("request")
+                .method(method)
+                .url(url)
+                .body(body)
+                .build());
+    }
+
+    public void logResponse(String sessionId, int status, String body, long latencyMs) {
+        write(Entry.builder()
+                .id(UUID.randomUUID().toString())
+                .timestamp(Instant.now().toString())
+                .sessionId(normalize(sessionId))
+                .direction("response")
+                .status(status)
+                .latencyMs(latencyMs)
+                .body(body)
+                .build());
+    }
+
+    /**
+     * Application-level entry for events that don't map cleanly to a single HTTP
+     * exchange (e.g. final aggregated answer of a streaming chat).
+     */
+    public void logLogical(String sessionId, String direction, String label, String body, Long latencyMs) {
+        write(Entry.builder()
+                .id(UUID.randomUUID().toString())
+                .timestamp(Instant.now().toString())
+                .sessionId(normalize(sessionId))
+                .direction(direction)
+                .summary(label)
+                .body(body)
+                .latencyMs(latencyMs)
+                .build());
+    }
+
+    private void write(Entry entry) {
+        FILE_LOG.info(toJson(entry));
+    }
+
+    private String toJson(Entry entry) {
+        try {
+            ObjectNode node = objectMapper.valueToTree(entry);
+            String body = entry.getBody();
+            if (body != null && body.length() > MAX_BODY_CHARS_IN_FILE) {
+                node.put("body", body.substring(0, MAX_BODY_CHARS_IN_FILE)
+                        + "…[truncated " + (body.length() - MAX_BODY_CHARS_IN_FILE) + " chars]");
+            }
+            return objectMapper.writeValueAsString(node);
+        } catch (JsonProcessingException e) {
+            return "{\"error\":\"failed to serialize entry\"}";
+        }
+    }
+
+    private String normalize(String sessionId) {
+        return (sessionId == null || sessionId.isBlank()) ? UNKNOWN_SESSION : sessionId;
+    }
+
+    @Value
+    @Builder
+    public static class Entry {
+        String id;
+        String timestamp;
+        String sessionId;
+        String direction;     // "request" | "response"
+        String method;
+        String url;
+        Integer status;
+        Long latencyMs;
+        String summary;
+        String body;
+    }
+}

--- a/src/main/java/com/dawn/ai/config/SessionAwareExecutor.java
+++ b/src/main/java/com/dawn/ai/config/SessionAwareExecutor.java
@@ -1,0 +1,92 @@
+package com.dawn.ai.config;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+/**
+ * ExecutorService decorator that captures the current
+ * {@link AiInteractionContext} sessionId on submission and restores it on the
+ * worker thread before the task runs. Use to wrap pools that handle work
+ * delegated from a chat thread (e.g. RAG retrieval, embedding lookups) so
+ * downstream HTTP interceptors can attribute requests back to the origin
+ * session.
+ */
+public class SessionAwareExecutor implements ExecutorService {
+
+    private final ExecutorService delegate;
+
+    public SessionAwareExecutor(ExecutorService delegate) {
+        this.delegate = delegate;
+    }
+
+    @Override
+    public void execute(Runnable command) {
+        delegate.execute(AiInteractionContext.wrap(command));
+    }
+
+    @Override
+    public Future<?> submit(Runnable task) {
+        return delegate.submit(AiInteractionContext.wrap(task));
+    }
+
+    @Override
+    public <T> Future<T> submit(Runnable task, T result) {
+        return delegate.submit(AiInteractionContext.wrap(task), result);
+    }
+
+    @Override
+    public <T> Future<T> submit(Callable<T> task) {
+        return delegate.submit(AiInteractionContext.wrap(task));
+    }
+
+    @Override
+    public <T> List<Future<T>> invokeAll(Collection<? extends Callable<T>> tasks) throws InterruptedException {
+        return delegate.invokeAll(wrapAll(tasks));
+    }
+
+    @Override
+    public <T> List<Future<T>> invokeAll(Collection<? extends Callable<T>> tasks, long timeout, TimeUnit unit)
+            throws InterruptedException {
+        return delegate.invokeAll(wrapAll(tasks), timeout, unit);
+    }
+
+    @Override
+    public <T> T invokeAny(Collection<? extends Callable<T>> tasks)
+            throws InterruptedException, ExecutionException {
+        return delegate.invokeAny(wrapAll(tasks));
+    }
+
+    @Override
+    public <T> T invokeAny(Collection<? extends Callable<T>> tasks, long timeout, TimeUnit unit)
+            throws InterruptedException, ExecutionException, TimeoutException {
+        return delegate.invokeAny(wrapAll(tasks), timeout, unit);
+    }
+
+    private <T> Collection<? extends Callable<T>> wrapAll(Collection<? extends Callable<T>> tasks) {
+        return tasks.stream().map(AiInteractionContext::wrap).collect(Collectors.toList());
+    }
+
+    @Override
+    public void shutdown() { delegate.shutdown(); }
+
+    @Override
+    public List<Runnable> shutdownNow() { return delegate.shutdownNow(); }
+
+    @Override
+    public boolean isShutdown() { return delegate.isShutdown(); }
+
+    @Override
+    public boolean isTerminated() { return delegate.isTerminated(); }
+
+    @Override
+    public boolean awaitTermination(long timeout, TimeUnit unit) throws InterruptedException {
+        return delegate.awaitTermination(timeout, unit);
+    }
+}

--- a/src/main/java/com/dawn/ai/controller/AiInteractionController.java
+++ b/src/main/java/com/dawn/ai/controller/AiInteractionController.java
@@ -1,0 +1,246 @@
+package com.dawn.ai.controller;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.io.IOException;
+import java.io.RandomAccessFile;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Deque;
+import java.util.List;
+
+/**
+ * Exposes the {@code ai_interaction.log} file (written by {@link com.dawn.ai.config.AiInteractionLogger})
+ * as plain text or browser-friendly pretty-printed HTML for the frontend
+ * "Interactions" link to view.
+ *
+ * <p>Endpoint: {@code GET /api/v1/ai-interactions/log[?tail=N&sessionId=xxx]}
+ *
+ * <ul>
+ *   <li>{@code tail} — number of trailing lines to return (default 500, max 5000).</li>
+ *   <li>{@code sessionId} — optional, return only lines whose JSON contains the matching sessionId.</li>
+ *   <li>{@code pretty} — optional, render the response as HTML with pretty-printed JSON.</li>
+ * </ul>
+ */
+@Slf4j
+@RestController
+@RequestMapping("/api/v1/ai-interactions")
+@RequiredArgsConstructor
+public class AiInteractionController {
+
+    private static final int DEFAULT_TAIL = 500;
+    private static final int MAX_TAIL = 5_000;
+    private static final MediaType HTML_UTF8 = MediaType.parseMediaType("text/html;charset=UTF-8");
+
+    private final ObjectMapper objectMapper;
+
+    @Value("${app.ai.interaction-log.path:logs/ai_interaction.log}")
+    private String logPath;
+
+    @GetMapping(value = "/log", produces = {MediaType.TEXT_PLAIN_VALUE, MediaType.TEXT_HTML_VALUE})
+    public ResponseEntity<String> tailLog(
+            @RequestParam(required = false, defaultValue = "500") int tail,
+            @RequestParam(required = false) String sessionId,
+            @RequestParam(required = false, defaultValue = "false") boolean pretty) {
+
+        int requested = Math.max(1, Math.min(tail <= 0 ? DEFAULT_TAIL : tail, MAX_TAIL));
+
+        Path file = Paths.get(logPath);
+        if (!Files.exists(file)) {
+            String message = "(no interactions yet — file " + file.toAbsolutePath() + " not created)";
+            return pretty ? htmlResponse("AI Interaction Log", message) : plainTextResponse(message);
+        }
+
+        try {
+            List<String> lines = readLastLines(file, requested);
+            boolean filtering = sessionId != null && !sessionId.isBlank();
+            if (filtering) {
+                String needle = "\"sessionId\":\"" + sessionId + "\"";
+                lines = lines.stream().filter(l -> l.contains(needle)).toList();
+            }
+            if (lines.isEmpty()) {
+                String message = filtering
+                        ? "(no entries for sessionId=" + sessionId + " in last " + requested + " lines)"
+                        : "(log file is empty — no AI interactions recorded yet)";
+                return pretty ? htmlResponse("AI Interaction Log", message) : plainTextResponse(message);
+            }
+            if (pretty) {
+                String title = filtering
+                        ? "AI Interaction Log — sessionId=" + sessionId
+                        : "AI Interaction Log";
+                return htmlResponse(title, buildPrettyLog(lines));
+            }
+            return plainTextResponse(String.join("\n", lines));
+        } catch (IOException e) {
+            log.warn("[AiInteractionController] failed to tail {}: {}", file, e.getMessage());
+            return ResponseEntity.status(500).body("Failed to read log file: " + e.getMessage());
+        }
+    }
+
+    private ResponseEntity<String> plainTextResponse(String body) {
+        return ResponseEntity.ok()
+                .contentType(MediaType.TEXT_PLAIN)
+                .body(body + "\n");
+    }
+
+    private ResponseEntity<String> htmlResponse(String title, String content) {
+        String html = """
+                <!DOCTYPE html>
+                <html lang="en">
+                <head>
+                    <meta charset="UTF-8">
+                    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+                    <title>%s</title>
+                    <style>
+                        :root {
+                            color-scheme: light dark;
+                        }
+                        body {
+                            margin: 0;
+                            padding: 24px;
+                            font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
+                            background: #0b1020;
+                            color: #e5e7eb;
+                        }
+                        .log-shell {
+                            max-width: 1200px;
+                            margin: 0 auto;
+                        }
+                        h1 {
+                            margin: 0 0 16px;
+                            font-size: 20px;
+                        }
+                        .log-output {
+                            margin: 0;
+                            padding: 20px;
+                            white-space: pre-wrap;
+                            word-break: break-word;
+                            background: rgba(15, 23, 42, 0.92);
+                            border: 1px solid rgba(148, 163, 184, 0.25);
+                            border-radius: 12px;
+                            line-height: 1.5;
+                        }
+                    </style>
+                </head>
+                <body>
+                    <main class="log-shell">
+                        <h1>%s</h1>
+                        <pre class="log-output">%s</pre>
+                    </main>
+                </body>
+                </html>
+                """.formatted(escapeHtml(title), escapeHtml(title), escapeHtml(content));
+        return ResponseEntity.ok()
+                .contentType(HTML_UTF8)
+                .body(html);
+    }
+
+    private String buildPrettyLog(List<String> lines) {
+        return lines.stream()
+                .map(this::prettyPrintLine)
+                .reduce((left, right) -> left + "\n\n" + right)
+                .orElse("");
+    }
+
+    private String prettyPrintLine(String line) {
+        try {
+            JsonNode node = objectMapper.readTree(line);
+            return objectMapper.writerWithDefaultPrettyPrinter()
+                    .writeValueAsString(expandEmbeddedJson(node));
+        } catch (IOException e) {
+            return line;
+        }
+    }
+
+    private JsonNode expandEmbeddedJson(JsonNode node) {
+        if (!(node instanceof ObjectNode objectNode)) {
+            return node;
+        }
+        ObjectNode copy = objectNode.deepCopy();
+        JsonNode bodyNode = copy.get("body");
+        if (bodyNode != null && bodyNode.isTextual()) {
+            JsonNode parsedBody = tryParseJson(bodyNode.asText());
+            if (parsedBody != null) {
+                copy.set("body", parsedBody);
+            }
+        }
+        return copy;
+    }
+
+    private JsonNode tryParseJson(String text) {
+        if (text == null) {
+            return null;
+        }
+        String trimmed = text.trim();
+        if (trimmed.isEmpty()) {
+            return null;
+        }
+        char first = trimmed.charAt(0);
+        if (first != '{' && first != '[') {
+            return null;
+        }
+        try {
+            return objectMapper.readTree(trimmed);
+        } catch (IOException e) {
+            return null;
+        }
+    }
+
+    private String escapeHtml(String value) {
+        if (value == null) {
+            return "";
+        }
+        return value
+                .replace("&", "&amp;")
+                .replace("<", "&lt;")
+                .replace(">", "&gt;")
+                .replace("\"", "&quot;");
+    }
+
+    /**
+     * Read the last {@code n} lines of {@code file} efficiently by scanning backwards
+     * through the file in 8 KB chunks. Avoids loading the whole file into memory.
+     */
+    private List<String> readLastLines(Path file, int n) throws IOException {
+        Deque<String> buffer = new ArrayDeque<>(n);
+        try (RandomAccessFile raf = new RandomAccessFile(file.toFile(), "r")) {
+            long pos = raf.length();
+            byte[] chunk = new byte[8 * 1024];
+            StringBuilder leftover = new StringBuilder();
+            while (pos > 0 && buffer.size() < n) {
+                int read = (int) Math.min(chunk.length, pos);
+                pos -= read;
+                raf.seek(pos);
+                raf.readFully(chunk, 0, read);
+                String text = new String(chunk, 0, read, StandardCharsets.UTF_8);
+                String combined = text + leftover;
+                String[] parts = combined.split("\n", -1);
+                // first segment may be partial — keep for next iteration
+                leftover.setLength(0);
+                leftover.append(parts[0]);
+                for (int i = parts.length - 1; i >= 1 && buffer.size() < n; i--) {
+                    if (!parts[i].isEmpty()) buffer.addFirst(parts[i]);
+                }
+            }
+            if (leftover.length() > 0 && buffer.size() < n) {
+                buffer.addFirst(leftover.toString());
+            }
+        }
+        return new ArrayList<>(buffer);
+    }
+}

--- a/src/main/java/com/dawn/ai/memory/ImportanceDecayManager.java
+++ b/src/main/java/com/dawn/ai/memory/ImportanceDecayManager.java
@@ -1,0 +1,132 @@
+package com.dawn.ai.memory;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.stream.Stream;
+
+/**
+ * Periodically decays the {@code importance} metadata field of memory documents
+ * based on how long ago they were last accessed ({@code lastAccessedAt}).
+ *
+ * <p>Formula (exponential decay with configurable half-life):
+ * <pre>
+ *   decayed = max(minImportance, current × 0.5 ^ (daysSinceAccess / halfLifeDays))
+ * </pre>
+ *
+ * <p>After {@code halfLifeDays} days without any retrieval hit, importance halves.
+ * Documents that decay below {@code app.memory.eviction.importance-threshold} will
+ * subsequently be cleaned up by {@link EvictionPolicyManager}.
+ *
+ * <p>Uses {@link NamedParameterJdbcTemplate} directly to UPDATE the pgvector
+ * {@code vector_store} table's metadata JSONB — avoids re-embedding on every decay cycle.
+ */
+@Slf4j
+@Service
+public class ImportanceDecayManager {
+
+    private static final double LN2 = Math.log(2);
+    // Only write back when the change is meaningful (avoids noisy DB churn)
+    private static final double MIN_DELTA = 0.001;
+
+    private static final String SQL_SELECT_CANDIDATES = """
+            SELECT id,
+                   (metadata->>'importance')::float                                              AS importance,
+                   COALESCE((metadata->>'lastAccessedAt')::bigint,
+                            (metadata->>'createdAt')::bigint)                                    AS last_accessed_at
+            FROM vector_store
+            WHERE metadata->>'type' IN ('summary')
+              AND metadata ? 'importance'
+              AND metadata ? 'createdAt'
+            LIMIT :batchSize
+            """;
+
+    private static final String SQL_UPDATE_IMPORTANCE = """
+            UPDATE vector_store
+            SET metadata = jsonb_set(metadata, '{importance}', to_jsonb(:importance::float8))
+            WHERE id = :id::uuid
+            """;
+
+    private final NamedParameterJdbcTemplate jdbc;
+    private final double halfLifeDays;
+    private final double minImportance;
+    private final int batchSize;
+
+    public ImportanceDecayManager(
+            NamedParameterJdbcTemplate jdbc,
+            @Value("${app.memory.decay.half-life-days:30}") double halfLifeDays,
+            @Value("${app.memory.decay.min-importance:0.01}") double minImportance,
+            @Value("${app.memory.decay.batch-size:500}") int batchSize) {
+        this.jdbc = jdbc;
+        this.halfLifeDays = halfLifeDays;
+        this.minImportance = minImportance;
+        this.batchSize = batchSize;
+    }
+
+    /** Runs daily at 03:30, 30 minutes after the eviction job (03:00). */
+    @Scheduled(cron = "${app.memory.decay.cron:0 30 3 * * ?}")
+    public void decay() {
+        long nowMs = Instant.now().toEpochMilli();
+
+        List<DecayCandidate> candidates;
+        try {
+            candidates = jdbc.query(
+                    SQL_SELECT_CANDIDATES,
+                    new MapSqlParameterSource("batchSize", batchSize),
+                    (rs, rowNum) -> new DecayCandidate(
+                            rs.getString("id"),
+                            rs.getDouble("importance"),
+                            rs.getLong("last_accessed_at")
+                    ));
+        } catch (Exception e) {
+            log.warn("[ImportanceDecayManager] Failed to fetch decay candidates: {}", e.getMessage());
+            return;
+        }
+
+        MapSqlParameterSource[] updates = candidates.stream()
+                .flatMap(c -> {
+                    double decayed = computeDecay(c.importance(), c.lastAccessedAt(), nowMs);
+                    return Math.abs(decayed - c.importance()) >= MIN_DELTA
+                            ? Stream.of(new MapSqlParameterSource()
+                                    .addValue("id", c.id())
+                                    .addValue("importance", decayed))
+                            : Stream.empty();
+                })
+                .toArray(MapSqlParameterSource[]::new);
+
+        if (updates.length == 0) {
+            log.debug("[ImportanceDecayManager] No documents require importance decay");
+            return;
+        }
+
+        jdbc.batchUpdate(SQL_UPDATE_IMPORTANCE, updates);
+        log.info("[ImportanceDecayManager] Decayed importance for {} documents (halfLife={}d, min={})",
+                updates.length, halfLifeDays, minImportance);
+    }
+
+    /**
+     * Computes decayed importance. Package-private for unit testing.
+     *
+     * @param currentImportance current stored importance (0.0–1.0)
+     * @param lastAccessedAtMs  epoch millis of last retrieval hit
+     * @param nowMs             current epoch millis
+     * @return decayed importance, floored at {@code minImportance}
+     */
+    double computeDecay(double currentImportance, long lastAccessedAtMs, long nowMs) {
+        double daysSinceAccess = (nowMs - lastAccessedAtMs) / 86_400_000.0;
+        if (daysSinceAccess <= 0) {
+            return currentImportance;
+        }
+        double decayed = currentImportance * Math.exp(-LN2 * daysSinceAccess / halfLifeDays);
+        return Math.max(minImportance, decayed);
+    }
+
+    // Package-private for test visibility
+    record DecayCandidate(String id, double importance, long lastAccessedAt) {}
+}

--- a/src/main/java/com/dawn/ai/memory/MemoryAccessUpdater.java
+++ b/src/main/java/com/dawn/ai/memory/MemoryAccessUpdater.java
@@ -1,0 +1,69 @@
+package com.dawn.ai.memory;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.ai.document.Document;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+
+import java.time.Instant;
+import java.util.List;
+
+/**
+ * Asynchronously refreshes the {@code lastAccessedAt} metadata field for memory
+ * documents that were hit during a retrieval call.
+ *
+ * <p>Only documents with a {@code type} metadata key are updated — these are
+ * exclusively memory pipeline documents (summary, reflection). RAG knowledge
+ * documents (ingested via {@code RagService.ingest}) have no {@code type} field
+ * and are deliberately left untouched.
+ *
+ * <p>The update is fire-and-forget: failures are logged but never propagate to
+ * the caller.
+ */
+@Slf4j
+@Component
+public class MemoryAccessUpdater {
+
+    private static final String SQL_UPDATE_LAST_ACCESSED = """
+            UPDATE vector_store
+            SET metadata = jsonb_set(metadata, '{lastAccessedAt}', to_jsonb(:nowMs::bigint))
+            WHERE id = :id::uuid
+            """;
+
+    private final NamedParameterJdbcTemplate jdbc;
+
+    public MemoryAccessUpdater(NamedParameterJdbcTemplate jdbc) {
+        this.jdbc = jdbc;
+    }
+
+    /**
+     * Filters the given documents to memory-only ones and updates their
+     * {@code lastAccessedAt} asynchronously.
+     *
+     * @param docs documents returned by a retrieval call
+     */
+    @Async
+    public void updateAccessTime(List<Document> docs) {
+        long nowMs = Instant.now().toEpochMilli();
+
+        MapSqlParameterSource[] params = docs.stream()
+                .filter(doc -> doc.getMetadata().containsKey("type"))   // memory docs only
+                .map(doc -> new MapSqlParameterSource()
+                        .addValue("id", doc.getId())
+                        .addValue("nowMs", nowMs))
+                .toArray(MapSqlParameterSource[]::new);
+
+        if (params.length == 0) {
+            return;
+        }
+
+        try {
+            jdbc.batchUpdate(SQL_UPDATE_LAST_ACCESSED, params);
+            log.debug("[MemoryAccessUpdater] Updated lastAccessedAt for {} memory docs", params.length);
+        } catch (Exception e) {
+            log.warn("[MemoryAccessUpdater] Failed to update lastAccessedAt: {}", e.getMessage());
+        }
+    }
+}

--- a/src/main/java/com/dawn/ai/rag/RagService.java
+++ b/src/main/java/com/dawn/ai/rag/RagService.java
@@ -1,6 +1,7 @@
 package com.dawn.ai.rag;
 
 import com.dawn.ai.config.AiAvailabilityChecker;
+import com.dawn.ai.memory.MemoryAccessUpdater;
 import com.dawn.ai.rag.ingestion.OverlapTextSplitter;
 import com.dawn.ai.rag.retrieval.fusion.ReciprocalRankFusion;
 import com.dawn.ai.rag.retrieval.RetrievalRequest;
@@ -54,6 +55,7 @@ public class RagService {
     // application defines multiple ExecutorService beans and this dependency must
     // bind to the retrieval pool rather than relying on type-only resolution.
     private final ExecutorService ragRetrievalExecutor;
+    private final MemoryAccessUpdater memoryAccessUpdater;
 
     public RagService(VectorStore vectorStore,
                       MeterRegistry meterRegistry,
@@ -63,7 +65,8 @@ public class RagService {
                       ReciprocalRankFusion reciprocalRankFusion,
                       RetrievalRouter retrievalRouter,
                       DocumentTransformer splitter,
-                      @Qualifier("ragRetrievalExecutor") ExecutorService ragRetrievalExecutor) {
+                      @Qualifier("ragRetrievalExecutor") ExecutorService ragRetrievalExecutor,
+                      MemoryAccessUpdater memoryAccessUpdater) {
         this.vectorStore = vectorStore;
         this.meterRegistry = meterRegistry;
         this.aiAvailabilityChecker = aiAvailabilityChecker;
@@ -73,6 +76,7 @@ public class RagService {
         this.retrievalRouter = retrievalRouter;
         this.splitter = splitter;
         this.ragRetrievalExecutor = ragRetrievalExecutor;
+        this.memoryAccessUpdater = memoryAccessUpdater;
     }
 
     @Setter
@@ -205,6 +209,9 @@ public class RagService {
         log.info("[RagService] Retrieved {}/{} docs (strategy={}, threshold={}, filtered={}), query='{}', metadataFilters={}",
                 limited.size(), candidateCount, strategy, similarityThreshold, filteredOut,
                 retrievalRequest.getQuery(), retrievalRequest.getMetadataFilters());
+        // Async: refresh lastAccessedAt for memory docs (type=summary/reflection) that were hit.
+        // RAG knowledge docs have no 'type' field and are silently skipped inside the updater.
+        memoryAccessUpdater.updateAccessTime(limited);
         return limited;
     }
 

--- a/src/main/java/com/dawn/ai/service/ChatService.java
+++ b/src/main/java/com/dawn/ai/service/ChatService.java
@@ -4,6 +4,8 @@ import com.dawn.ai.agent.orchestration.AgentOrchestrator;
 import com.dawn.ai.agent.orchestration.AgentResult;
 import com.dawn.ai.agent.planning.PlanStep;
 import com.dawn.ai.config.AiAvailabilityChecker;
+import com.dawn.ai.config.AiInteractionContext;
+import com.dawn.ai.config.AiInteractionLogger;
 import com.dawn.ai.dto.ChatRequest;
 import com.dawn.ai.dto.ChatResponse;
 import com.dawn.ai.sse.ChatStreamEvent;
@@ -34,6 +36,7 @@ public class ChatService {
     private final AiAvailabilityChecker aiAvailabilityChecker;
     private final ExecutorService chatStreamExecutor;
     private final ObjectMapper objectMapper;
+    private final AiInteractionLogger aiInteractionLogger;
 
     @Value("${app.ai.react.show-steps:false}")
     private boolean showSteps;
@@ -48,12 +51,14 @@ public class ChatService {
                        ChatClient chatClient,
                        AiAvailabilityChecker aiAvailabilityChecker,
                        @Qualifier("chatStreamExecutor") ExecutorService chatStreamExecutor,
-                       ObjectMapper objectMapper) {
+                       ObjectMapper objectMapper,
+                       AiInteractionLogger aiInteractionLogger) {
         this.agentOrchestrator = agentOrchestrator;
         this.chatClient = chatClient;
         this.aiAvailabilityChecker = aiAvailabilityChecker;
         this.chatStreamExecutor = chatStreamExecutor;
         this.objectMapper = objectMapper;
+        this.aiInteractionLogger = aiInteractionLogger;
     }
 
     public ChatResponse chat(ChatRequest request) {
@@ -67,17 +72,98 @@ public class ChatService {
 
         String userMessage = request.getMessage();
 
-        AgentResult result = agentOrchestrator.chat(sessionId, userMessage, request.getTopicId());
+        AiInteractionContext.setSessionId(sessionId);
+        writeLogicalChatRequest(sessionId, request, false);
+        try {
+            AgentResult result = agentOrchestrator.chat(sessionId, userMessage, request.getTopicId());
 
-        return ChatResponse.builder()
-                .sessionId(sessionId)
-                .answer(result.finalAnswer())
-                .steps(showSteps ? result.steps() : null)
-                .planSummary(formatPlanSummary(result.plan()))
-                .totalSteps(result.steps().size())
-                .durationMs(System.currentTimeMillis() - start)
-                .model(model)
-                .build();
+            ChatResponse response = ChatResponse.builder()
+                    .sessionId(sessionId)
+                    .answer(result.finalAnswer())
+                    .steps(showSteps ? result.steps() : null)
+                    .planSummary(formatPlanSummary(result.plan()))
+                    .totalSteps(result.steps().size())
+                    .durationMs(System.currentTimeMillis() - start)
+                    .model(model)
+                    .build();
+
+            writeLogicalSyncChatResponse(sessionId, result, response);
+            return response;
+        } finally {
+            AiInteractionContext.clear();
+        }
+    }
+
+    private void writeLogicalChatRequest(String sessionId, ChatRequest request, boolean stream) {
+        try {
+            String body = objectMapper.writeValueAsString(java.util.Map.of(
+                    "model", model,
+                    "stream", stream,
+                    "userMessage", request.getMessage(),
+                    "topicId", request.getTopicId() == null ? "" : request.getTopicId(),
+                    "sessionId", sessionId
+            ));
+            String label = (stream ? "Stream chat → " : "Sync chat → ") + truncate(request.getMessage(), 80);
+            aiInteractionLogger.logLogical(sessionId, "request", label, body, null);
+        } catch (Exception e) {
+            log.warn("[ChatService] failed to write logical request: {}", e.getMessage());
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private void writeLogicalChatResponse(String sessionId, Object doneData, long latencyMs) {
+        try {
+            java.util.Map<String, Object> data = doneData instanceof java.util.Map
+                    ? (java.util.Map<String, Object>) doneData
+                    : java.util.Map.of();
+            String answer = String.valueOf(data.getOrDefault("answer", ""));
+            String body = objectMapper.writeValueAsString(java.util.Map.of(
+                    "model", data.getOrDefault("model", model),
+                    "answer", answer,
+                    "totalSteps", data.getOrDefault("totalSteps", 0),
+                    "planSummary", data.getOrDefault("planSummary", ""),
+                    "durationMs", data.getOrDefault("durationMs", latencyMs)
+            ));
+            aiInteractionLogger.logLogical(sessionId, "response", "Stream chat answer", body, latencyMs);
+        } catch (Exception e) {
+            log.warn("[ChatService] failed to write logical response: {}", e.getMessage());
+        }
+    }
+
+    private void writeLogicalSyncChatResponse(String sessionId, AgentResult result, ChatResponse response) {
+        try {
+            String body = objectMapper.writeValueAsString(java.util.Map.of(
+                    "model", response.getModel() == null ? model : response.getModel(),
+                    "answer", result.finalAnswer() == null ? "" : result.finalAnswer(),
+                    "totalSteps", response.getTotalSteps(),
+                    "planSummary", response.getPlanSummary() == null ? "" : response.getPlanSummary(),
+                    "durationMs", response.getDurationMs()
+            ));
+            aiInteractionLogger.logLogical(sessionId, "response", "Sync chat answer", body, response.getDurationMs());
+        } catch (Exception e) {
+            log.warn("[ChatService] failed to write sync logical response: {}", e.getMessage());
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private void writeLogicalChatError(String sessionId, Object errorData) {
+        try {
+            java.util.Map<String, Object> data = errorData instanceof java.util.Map
+                    ? (java.util.Map<String, Object>) errorData
+                    : java.util.Map.of();
+            String body = objectMapper.writeValueAsString(java.util.Map.of(
+                    "code", data.getOrDefault("code", "ERROR"),
+                    "message", data.getOrDefault("message", "")
+            ));
+            aiInteractionLogger.logLogical(sessionId, "response", "Stream chat error", body, null);
+        } catch (Exception e) {
+            log.warn("[ChatService] failed to write logical error: {}", e.getMessage());
+        }
+    }
+
+    private String truncate(String s, int max) {
+        if (s == null) return "";
+        return s.length() <= max ? s : s.substring(0, max) + "…";
     }
 
     /** Simple one-shot chat without memory or tools */
@@ -125,15 +211,27 @@ public class ChatService {
 
         try {
             chatStreamExecutor.execute(() -> {
+                AiInteractionContext.setSessionId(sessionId);
+                long startedAt = System.currentTimeMillis();
+                writeLogicalChatRequest(sessionId, request, true);
                 try {
                     sendEvent(emitter, ChatStreamEvent.connected(sessionId, streamId), seqCounter);
                     agentOrchestrator.streamChat(sessionId, request.getMessage(), request.getTopicId(),
-                            event -> sendEvent(emitter, event, seqCounter),
+                            event -> {
+                                sendEvent(emitter, event, seqCounter);
+                                if ("done".equals(event.getEvent())) {
+                                    writeLogicalChatResponse(sessionId, event.getData(),
+                                            System.currentTimeMillis() - startedAt);
+                                } else if ("error".equals(event.getEvent())) {
+                                    writeLogicalChatError(sessionId, event.getData());
+                                }
+                            },
                             cancelled::get);
                 } catch (Exception e) {
                     log.error("[ChatService] Unexpected error in stream thread, sessionId={}", sessionId, e);
                     sendEvent(emitter, ChatStreamEvent.error(sessionId, "INTERNAL_ERROR", e.getMessage()), seqCounter);
                 } finally {
+                    AiInteractionContext.clear();
                     try { emitter.complete(); } catch (IllegalStateException ignored) {}
                 }
             });

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -78,7 +78,7 @@ app:
     react:
       max-steps: 10        # 单次对话最多工具调用次数（超出时 LLM 自行收敛）
       show-steps: true    # 响应体中是否包含 steps 详情
-      plan-enabled: false   # 是否启用执行前规划（关闭后跳过 TaskPlanner)
+      plan-enabled: true   # 是否启用执行前规划（关闭后跳过 TaskPlanner)
     stream:
       timeout-ms: 1200000   # SSE 单次请求最大等待时长（毫秒）
     rag:
@@ -116,6 +116,11 @@ app:
       cron: "0 0 3 * * ?"
       importance-threshold: 0.1
       max-age-days: 2
+    decay:
+      cron: "0 30 3 * * ?"     # 每天 03:30，eviction (03:00) 之后运行
+      half-life-days: 30        # 30 天无访问后 importance 减半
+      min-importance: 0.01      # importance 衰减下限，低于此值保持不变
+      batch-size: 500           # 每次扫描文档数上限
     reflection:
       episode-threshold: 4 # ReflectionWorker 至少需要 ≥2 个 episode 才执行
 

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+
+    <property name="LOG_PATH" value="${LOG_PATH:-logs}"/>
+    <property name="CONSOLE_PATTERN"
+              value="%d{yyyy-MM-dd HH:mm:ss} [%thread] %-5level %logger{36}:%line - %msg%n"/>
+
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>${CONSOLE_PATTERN}</pattern>
+        </encoder>
+    </appender>
+
+    <appender name="AI_INTERACTION_FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>${LOG_PATH}/ai_interaction.log</file>
+        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+            <fileNamePattern>${LOG_PATH}/ai_interaction.%d{yyyy-MM-dd}.%i.log</fileNamePattern>
+            <maxFileSize>20MB</maxFileSize>
+            <maxHistory>14</maxHistory>
+            <totalSizeCap>500MB</totalSizeCap>
+        </rollingPolicy>
+        <encoder>
+            <pattern>%msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <logger name="AI_INTERACTION" level="INFO" additivity="false">
+        <appender-ref ref="AI_INTERACTION_FILE"/>
+    </logger>
+
+    <logger name="com.dawn.ai" level="DEBUG"/>
+    <logger name="org.springframework.ai" level="INFO"/>
+
+    <root level="INFO">
+        <appender-ref ref="CONSOLE"/>
+    </root>
+</configuration>

--- a/src/main/resources/static/css/style.css
+++ b/src/main/resources/static/css/style.css
@@ -16,10 +16,14 @@
     --success: #2ecc71;
     --warning: #f39c12;
     --danger: #e74c3c;
-    --user-bubble: #4361ee;
-    --user-bubble-text: #ffffff;
-    --assistant-bubble: #f0f2f5;
-    --assistant-bubble-text: #212529;
+    --user-bubble: #f1f5f9;
+    --user-bubble-text: #0f172a;
+    --assistant-bubble: #ffffff;
+    --assistant-bubble-text: #0f172a;
+    --chat-text-tertiary: #64748b;
+    --chat-text-muted: #94a3b8;
+    --chat-border-faint: #e2e8f0;
+    --code-bg: #f3f4f6;
     --shadow-sm: 0 1px 3px rgba(0, 0, 0, 0.08);
     --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.1);
     --radius: 8px;
@@ -41,10 +45,14 @@
     --accent: #89b4fa;
     --accent-hover: #74c7ec;
     --accent-light: #1e2030;
-    --user-bubble: #89b4fa;
-    --user-bubble-text: #1e1e2e;
-    --assistant-bubble: #313244;
+    --user-bubble: #313244;
+    --user-bubble-text: #cdd6f4;
+    --assistant-bubble: #1e1e2e;
     --assistant-bubble-text: #cdd6f4;
+    --chat-text-tertiary: #a6adc8;
+    --chat-text-muted: #6c7086;
+    --chat-border-faint: #45475a;
+    --code-bg: #313244;
     --shadow-sm: 0 1px 3px rgba(0, 0, 0, 0.3);
     --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.4);
 }
@@ -234,32 +242,38 @@ html, body {
     border-color: var(--accent, #4a8eff);
 }
 
-/* ===== Chat ===== */
+/* ===== Chat (oMLX style) ===== */
 .chat-container {
     flex: 1;
     display: flex;
     flex-direction: column;
     overflow: hidden;
-    background: var(--bg-secondary);
+    background: var(--bg-primary);
+    position: relative;
 }
 
 .chat-messages {
     flex: 1;
     overflow-y: auto;
-    padding: 24px;
+    padding: 32px 24px 24px;
     display: flex;
     flex-direction: column;
-    gap: 16px;
+    gap: 20px;
+    align-items: stretch;
+    max-width: 880px;
+    width: 100%;
+    margin: 0 auto;
 }
 
 .welcome-message {
     text-align: center;
-    padding: 60px 20px;
+    padding: 80px 20px 40px;
     color: var(--text-secondary);
 }
 
 .welcome-message h3 {
-    font-size: 22px;
+    font-size: 24px;
+    font-weight: 600;
     color: var(--text-primary);
     margin-bottom: 8px;
 }
@@ -267,8 +281,8 @@ html, body {
 .message {
     display: flex;
     flex-direction: column;
-    max-width: 75%;
     animation: messageIn 0.3s ease;
+    max-width: 100%;
 }
 
 @keyframes messageIn {
@@ -278,31 +292,134 @@ html, body {
 
 .message.user {
     align-self: flex-end;
+    max-width: min(720px, 100%);
 }
 
 .message.assistant {
-    align-self: flex-start;
+    align-self: stretch;
+    max-width: 100%;
 }
 
 .message-bubble {
-    padding: 10px 16px;
-    border-radius: 16px;
-    line-height: 1.5;
+    line-height: 1.6;
     word-break: break-word;
-    white-space: pre-wrap;
+    overflow-wrap: anywhere;
+    min-width: 0;
 }
 
 .message.user .message-bubble {
     background: var(--user-bubble);
     color: var(--user-bubble-text);
-    border-bottom-right-radius: 4px;
+    border-radius: 18px;
+    padding: 10px 16px;
+    font-size: 14px;
 }
 
 .message.assistant .message-bubble {
     background: var(--assistant-bubble);
     color: var(--assistant-bubble-text);
-    border-bottom-left-radius: 4px;
+    border: 1px solid var(--chat-border-faint);
+    border-radius: 14px;
+    padding: 14px 18px;
+    font-size: 14px;
 }
+
+/* Markdown rendered content inside assistant bubble */
+.message.assistant .message-bubble > *:first-child { margin-top: 0; }
+.message.assistant .message-bubble > *:last-child { margin-bottom: 0; }
+.message-bubble p { margin: 0 0 0.85em; }
+.message-bubble p:last-child { margin-bottom: 0; }
+.message-bubble h1,
+.message-bubble h2,
+.message-bubble h3,
+.message-bubble h4 {
+    font-weight: 600;
+    margin: 1.2em 0 0.5em;
+    line-height: 1.3;
+    color: var(--text-primary);
+}
+.message-bubble h1 { font-size: 1.4em; }
+.message-bubble h2 { font-size: 1.25em; }
+.message-bubble h3 { font-size: 1.1em; }
+.message-bubble h4 { font-size: 1em; }
+.message-bubble ul,
+.message-bubble ol {
+    margin: 0 0 0.85em;
+    padding-left: 1.5em;
+}
+.message-bubble li { margin-bottom: 0.25em; }
+.message-bubble a { color: var(--accent); text-decoration: underline; }
+.message-bubble blockquote {
+    border-left: 3px solid var(--chat-border-faint);
+    color: var(--text-secondary);
+    padding: 2px 12px;
+    margin: 0 0 0.85em;
+}
+.message-bubble code {
+    background: var(--code-bg);
+    padding: 2px 5px;
+    border-radius: 4px;
+    font-size: 0.875em;
+    font-family: 'SF Mono', 'Fira Code', Consolas, monospace;
+}
+.message-bubble pre {
+    background: var(--code-bg);
+    border-radius: 8px;
+    padding: 12px 14px;
+    margin: 0.5em 0 0.85em;
+    overflow-x: auto;
+    font-size: 0.85em;
+    line-height: 1.5;
+    position: relative;
+}
+.message-bubble pre code {
+    background: transparent;
+    padding: 0;
+    border-radius: 0;
+    font-size: 1em;
+}
+.message-bubble table {
+    border-collapse: collapse;
+    margin: 0.5em 0 0.85em;
+    font-size: 0.9em;
+    display: block;
+    overflow-x: auto;
+    max-width: 100%;
+}
+.message-bubble th,
+.message-bubble td {
+    border: 1px solid var(--chat-border-faint);
+    padding: 6px 10px;
+    text-align: left;
+}
+.message-bubble th {
+    background: var(--bg-secondary);
+    font-weight: 600;
+}
+.message-bubble hr {
+    border: none;
+    border-top: 1px solid var(--chat-border-faint);
+    margin: 1em 0;
+}
+
+/* Code block copy button */
+.code-block-wrapper { position: relative; }
+.code-copy-btn {
+    position: absolute;
+    top: 6px;
+    right: 6px;
+    background: var(--bg-primary);
+    border: 1px solid var(--chat-border-faint);
+    border-radius: 5px;
+    padding: 3px 8px;
+    font-size: 11px;
+    cursor: pointer;
+    color: var(--text-secondary);
+    opacity: 0;
+    transition: opacity 0.15s;
+}
+.code-block-wrapper:hover .code-copy-btn { opacity: 1; }
+.code-copy-btn:hover { background: var(--bg-tertiary); color: var(--text-primary); }
 
 .message-meta {
     font-size: 11px;
@@ -482,11 +599,11 @@ html, body {
 /* Loading indicator */
 .typing-indicator {
     display: flex;
-    gap: 4px;
-    padding: 12px 16px;
+    gap: 6px;
+    padding: 14px 18px;
     background: var(--assistant-bubble);
-    border-radius: 16px;
-    border-bottom-left-radius: 4px;
+    border: 1px solid var(--chat-border-faint);
+    border-radius: 14px;
     align-self: flex-start;
     animation: messageIn 0.3s ease;
 }
@@ -509,25 +626,27 @@ html, body {
 
 /* Chat Input */
 .chat-input-area {
-    padding: 16px 24px;
+    padding: 16px 24px 24px;
     background: var(--bg-primary);
-    border-top: 1px solid var(--border-color);
     flex-shrink: 0;
+    max-width: 880px;
+    width: 100%;
+    margin: 0 auto;
 }
 
 .input-wrapper {
     display: flex;
     align-items: flex-end;
     gap: 8px;
-    background: var(--bg-secondary);
-    border: 1px solid var(--border-color);
-    border-radius: var(--radius-lg);
-    padding: 8px 12px;
+    background: var(--bg-primary);
+    border: 1px solid var(--chat-border-faint);
+    border-radius: 24px;
+    padding: 10px 14px;
     transition: border-color var(--transition);
 }
 
 .input-wrapper:focus-within {
-    border-color: var(--accent);
+    border-color: var(--chat-text-tertiary);
 }
 
 .input-wrapper textarea {
@@ -544,12 +663,12 @@ html, body {
 }
 
 .send-btn {
-    background: var(--accent);
-    color: white;
+    background: var(--text-primary);
+    color: var(--bg-primary);
     border: none;
-    width: 36px;
-    height: 36px;
-    border-radius: 8px;
+    width: 34px;
+    height: 34px;
+    border-radius: 50%;
     cursor: pointer;
     display: flex;
     align-items: center;
@@ -559,7 +678,7 @@ html, body {
 }
 
 .send-btn:hover {
-    background: var(--accent-hover);
+    opacity: 0.85;
 }
 
 .send-btn:disabled {
@@ -1118,3 +1237,26 @@ html, body {
         display: none;
     }
 }
+
+/* ===== AI Log link ===== */
+.interactions-toggle {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 4px 10px;
+    border: 1px solid var(--border-color);
+    border-radius: var(--radius);
+    background: transparent;
+    color: var(--text-secondary);
+    font-size: 12px;
+    text-decoration: none;
+    cursor: pointer;
+    transition: all var(--transition);
+}
+
+.interactions-toggle:hover {
+    background: var(--bg-secondary);
+    color: var(--text-primary);
+    border-color: var(--accent);
+}
+

--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -5,6 +5,13 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Dawn AI</title>
     <link rel="stylesheet" href="/css/style.css">
+
+    <!-- Markdown rendering & syntax highlighting (CDN) -->
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@11.9.0/build/styles/github.min.css" id="hljs-light-theme">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@11.9.0/build/styles/github-dark.min.css" id="hljs-dark-theme" disabled>
+    <script src="https://cdn.jsdelivr.net/npm/marked@12.0.2/marked.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/dompurify@3.0.11/dist/purify.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@11.9.0/build/highlight.min.js"></script>
 </head>
 <body>
     <div class="app">
@@ -49,6 +56,10 @@
                         <button class="btn-icon" id="newSessionBtn" title="New session">
                             <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>
                         </button>
+                        <a class="interactions-toggle" id="interactionsToggle" target="_blank" rel="noopener" title="Open AI interaction log in a new tab" href="/api/v1/ai-interactions/log?pretty=true">
+                            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/><line x1="16" y1="13" x2="8" y2="13"/><line x1="16" y1="17" x2="8" y2="17"/></svg>
+                            <span>AI Log</span>
+                        </a>
                     </div>
                 </div>
                 <div class="chat-container">
@@ -62,7 +73,7 @@
                         <div class="input-wrapper">
                             <textarea id="chatInput" placeholder="Type your message..." rows="1"></textarea>
                             <button class="send-btn" id="sendBtn" title="Send">
-                                <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="22" y1="2" x2="11" y2="13"/><polygon points="22 2 15 22 11 13 2 9 22 2"/></svg>
+                                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="22" y1="2" x2="11" y2="13"/><polygon points="22 2 15 22 11 13 2 9 22 2"/></svg>
                             </button>
                         </div>
                     </div>

--- a/src/main/resources/static/js/app.js
+++ b/src/main/resources/static/js/app.js
@@ -9,7 +9,60 @@ const API = {
     topics: '/api/v1/topics',
     health: '/actuator/health',
     metrics: '/actuator/metrics',
+    aiInteractionLog: '/api/v1/ai-interactions/log',
 };
+
+// ===== Markdown setup =====
+if (typeof marked !== 'undefined') {
+    marked.setOptions({
+        gfm: true,
+        breaks: true,
+        highlight(code, lang) {
+            if (typeof hljs === 'undefined') return code;
+            try {
+                if (lang && hljs.getLanguage(lang)) {
+                    return hljs.highlight(code, { language: lang, ignoreIllegals: true }).value;
+                }
+                return hljs.highlightAuto(code).value;
+            } catch {
+                return code;
+            }
+        },
+    });
+}
+
+function renderMarkdown(text) {
+    if (text == null) return '';
+    if (typeof marked === 'undefined' || typeof DOMPurify === 'undefined') {
+        return escapeHtml(text);
+    }
+    const html = marked.parse(String(text));
+    return DOMPurify.sanitize(html, { ADD_ATTR: ['target', 'class'] });
+}
+
+function enhanceCodeBlocks(root) {
+    if (!root) return;
+    const blocks = root.querySelectorAll('pre');
+    blocks.forEach(pre => {
+        if (pre.parentElement && pre.parentElement.classList.contains('code-block-wrapper')) return;
+        const wrapper = document.createElement('div');
+        wrapper.className = 'code-block-wrapper';
+        pre.parentNode.insertBefore(wrapper, pre);
+        wrapper.appendChild(pre);
+
+        const btn = document.createElement('button');
+        btn.className = 'code-copy-btn';
+        btn.textContent = 'Copy';
+        btn.addEventListener('click', () => {
+            const code = pre.querySelector('code')?.innerText ?? pre.innerText;
+            navigator.clipboard.writeText(code).then(() => {
+                btn.textContent = 'Copied!';
+                setTimeout(() => (btn.textContent = 'Copy'), 1500);
+            });
+        });
+        wrapper.appendChild(btn);
+    });
+}
 
 // ===== State =====
 const state = {
@@ -30,6 +83,7 @@ document.addEventListener('DOMContentLoaded', () => {
     initChat();
     initKnowledge();
     initDashboard();
+    initInteractionLogLink();
     newSession();
     refreshTopics();
 });
@@ -70,6 +124,7 @@ function initNavigation() {
 function initTheme() {
     const saved = localStorage.getItem('dawn-theme');
     if (saved === 'dark') document.documentElement.setAttribute('data-theme', 'dark');
+    syncHljsTheme();
 
     $('#themeToggle').addEventListener('click', () => {
         const isDark = document.documentElement.getAttribute('data-theme') === 'dark';
@@ -80,7 +135,16 @@ function initTheme() {
             document.documentElement.setAttribute('data-theme', 'dark');
             localStorage.setItem('dawn-theme', 'dark');
         }
+        syncHljsTheme();
     });
+}
+
+function syncHljsTheme() {
+    const dark = document.documentElement.getAttribute('data-theme') === 'dark';
+    const lightSheet = document.getElementById('hljs-light-theme');
+    const darkSheet = document.getElementById('hljs-dark-theme');
+    if (lightSheet) lightSheet.disabled = dark;
+    if (darkSheet) darkSheet.disabled = !dark;
 }
 
 // ===== Chat =====
@@ -126,6 +190,7 @@ function newSession() {
             <p>Start a conversation to test the AI agent.</p>
         </div>
     `;
+    updateInteractionLogLink();
 }
 
 async function sendMessage() {
@@ -257,7 +322,11 @@ function handleStreamEvent(type, envelope, assistantDiv) {
                 thinkingPanel.classList.add('done');
             }
             const bubble = assistantDiv.querySelector('.message-bubble');
-            bubble.textContent += data.content || '';
+            const prev = bubble.dataset.rawContent || '';
+            const next = prev + (data.content || '');
+            bubble.dataset.rawContent = next;
+            bubble.innerHTML = renderMarkdown(next);
+            enhanceCodeBlocks(bubble);
             $('#chatMessages').scrollTop = $('#chatMessages').scrollHeight;
             break;
         }
@@ -296,8 +365,9 @@ function handleStreamEvent(type, envelope, assistantDiv) {
             break;
         }
         case 'error': {
-            assistantDiv.querySelector('.message-bubble').textContent =
-                `[${data.code}] ${data.message}`;
+            const bubble = assistantDiv.querySelector('.message-bubble');
+            bubble.textContent = `[${data.code}] ${data.message}`;
+            bubble.dataset.rawContent = `[${data.code}] ${data.message}`;
             break;
         }
     }
@@ -462,13 +532,20 @@ function appendMessage(role, content, meta) {
         }
     }
 
+    const bubbleHtml = role === 'assistant'
+        ? renderMarkdown(content)
+        : escapeHtml(content);
+
     div.innerHTML = `
-        <div class="message-bubble">${escapeHtml(content)}</div>
+        <div class="message-bubble" data-raw-content="${escapeHtml(content || '')}">${bubbleHtml}</div>
         ${metaHtml}
         ${stepsHtml}
     `;
 
     container.appendChild(div);
+    if (role === 'assistant') {
+        enhanceCodeBlocks(div.querySelector('.message-bubble'));
+    }
     container.scrollTop = container.scrollHeight;
 }
 
@@ -917,4 +994,18 @@ function toast(message, type = 'info') {
     div.textContent = message;
     container.appendChild(div);
     setTimeout(() => div.remove(), 3000);
+}
+
+// ===== AI Interaction Log link =====
+function initInteractionLogLink() {
+    updateInteractionLogLink();
+}
+
+function updateInteractionLogLink() {
+    const link = $('#interactionsToggle');
+    if (!link) return;
+    const sid = state.sessionId;
+    const params = new URLSearchParams({ tail: '1000', pretty: 'true' });
+    if (sid) params.set('sessionId', sid);
+    link.href = `${API.aiInteractionLog}?${params.toString()}`;
 }

--- a/src/test/java/com/dawn/ai/controller/AiInteractionControllerTest.java
+++ b/src/test/java/com/dawn/ai/controller/AiInteractionControllerTest.java
@@ -1,0 +1,87 @@
+package com.dawn.ai.controller;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import static org.springframework.http.MediaType.TEXT_HTML;
+import static org.springframework.http.MediaType.TEXT_PLAIN;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(AiInteractionController.class)
+@Import(AiInteractionControllerTest.MeterConfig.class)
+@TestPropertySource(properties = "app.ai.interaction-log.path=target/test-logs/ai-interaction-controller.log")
+class AiInteractionControllerTest {
+
+    private static final Path LOG_FILE = Paths.get("target/test-logs/ai-interaction-controller.log");
+
+    @TestConfiguration
+    static class MeterConfig {
+        @Bean
+        MeterRegistry meterRegistry() {
+            return new SimpleMeterRegistry();
+        }
+    }
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @AfterEach
+    void cleanup() throws IOException {
+        Files.deleteIfExists(LOG_FILE);
+    }
+
+    @Test
+    void shouldReturnRawLogAsPlainTextByDefault() throws Exception {
+        writeLogLines("""
+                {"timestamp":"2026-05-09T21:00:00Z","sessionId":"session-1","direction":"response","body":"{\\"foo\\":1,\\"bar\\":true}"}
+                """);
+
+        mockMvc.perform(get("/api/v1/ai-interactions/log"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(TEXT_PLAIN))
+                .andExpect(content().string(org.hamcrest.Matchers.containsString(
+                        "\"body\":\"{\\\"foo\\\":1,\\\"bar\\\":true}\"")));
+    }
+
+    @Test
+    void shouldReturnPrettyPrintedHtmlWhenRequested() throws Exception {
+        writeLogLines(
+                """
+                {"timestamp":"2026-05-09T21:00:00Z","sessionId":"session-1","direction":"response","body":"{\\"foo\\":1,\\"bar\\":{\\"baz\\":true}}"}
+                {"timestamp":"2026-05-09T21:01:00Z","sessionId":"session-2","direction":"response","body":"plain text"}
+                """
+        );
+
+        mockMvc.perform(get("/api/v1/ai-interactions/log")
+                        .param("pretty", "true")
+                        .param("sessionId", "session-1"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(TEXT_HTML))
+                .andExpect(content().string(org.hamcrest.Matchers.containsString("<pre class=\"log-output\">")))
+                .andExpect(content().string(org.hamcrest.Matchers.containsString("&quot;sessionId&quot; : &quot;session-1&quot;")))
+                .andExpect(content().string(org.hamcrest.Matchers.containsString("&quot;body&quot; : {")))
+                .andExpect(content().string(org.hamcrest.Matchers.containsString("&quot;foo&quot; : 1")))
+                .andExpect(content().string(org.hamcrest.Matchers.not(org.hamcrest.Matchers.containsString("session-2"))));
+    }
+
+    private void writeLogLines(String content) throws IOException {
+        Files.createDirectories(LOG_FILE.getParent());
+        Files.writeString(LOG_FILE, content.strip() + System.lineSeparator());
+    }
+}

--- a/src/test/java/com/dawn/ai/memory/ImportanceDecayManagerTest.java
+++ b/src/test/java/com/dawn/ai/memory/ImportanceDecayManagerTest.java
@@ -1,0 +1,151 @@
+package com.dawn.ai.memory;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.jdbc.core.RowMapper;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.jdbc.core.namedparam.SqlParameterSource;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+class ImportanceDecayManagerTest {
+
+    private NamedParameterJdbcTemplate jdbc;
+    private ImportanceDecayManager manager;
+
+    // halfLifeDays=30, minImportance=0.01, batchSize=500
+    @BeforeEach
+    @SuppressWarnings("unchecked")
+    void setUp() {
+        jdbc = mock(NamedParameterJdbcTemplate.class);
+        manager = new ImportanceDecayManager(jdbc, 30.0, 0.01, 500);
+    }
+
+    // ── computeDecay unit tests ──────────────────────────────────────────────
+
+    @Test
+    void computeDecay_halvesImportanceAfterOneHalfLife() {
+        long now = Instant.now().toEpochMilli();
+        long thirtyDaysAgo = Instant.now().minus(30, ChronoUnit.DAYS).toEpochMilli();
+
+        double result = manager.computeDecay(0.5, thirtyDaysAgo, now);
+
+        // After exactly one half-life, importance should be ~0.25 (halved)
+        assertThat(result).isCloseTo(0.25, org.assertj.core.data.Offset.offset(0.001));
+    }
+
+    @Test
+    void computeDecay_respectsMinImportanceFloor() {
+        long now = Instant.now().toEpochMilli();
+        long veryOld = Instant.now().minus(1000, ChronoUnit.DAYS).toEpochMilli();
+
+        double result = manager.computeDecay(0.5, veryOld, now);
+
+        assertThat(result).isEqualTo(0.01); // clamped to minImportance
+    }
+
+    @Test
+    void computeDecay_noDecayForFutureOrNowTimestamp() {
+        long now = Instant.now().toEpochMilli();
+
+        assertThat(manager.computeDecay(0.5, now, now)).isEqualTo(0.5);
+        assertThat(manager.computeDecay(0.5, now + 1000, now)).isEqualTo(0.5); // future
+    }
+
+    @Test
+    void computeDecay_noDecayForRecentlyAccessedDoc() {
+        long now = Instant.now().toEpochMilli();
+        long oneHourAgo = Instant.now().minus(1, ChronoUnit.HOURS).toEpochMilli();
+
+        double result = manager.computeDecay(0.5, oneHourAgo, now);
+
+        // 1 hour / 30-day half-life → negligible decay, still very close to 0.5
+        assertThat(result).isGreaterThan(0.499);
+    }
+
+    // ── decay() integration tests (JDBC mocked) ──────────────────────────────
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void decay_appliesDecayToStaleDocuments() {
+        long oldTs = Instant.now().minus(30, ChronoUnit.DAYS).toEpochMilli(); // one half-life
+        var candidate = new ImportanceDecayManager.DecayCandidate("doc-1", 0.5, oldTs);
+
+        when(jdbc.query(anyString(), any(SqlParameterSource.class), any(RowMapper.class)))
+                .thenReturn(List.of(candidate));
+
+        manager.decay();
+
+        // batchUpdate should be called with 1 update (delta ≈ 0.25 >> MIN_DELTA)
+        verify(jdbc).batchUpdate(anyString(), argThat((MapSqlParameterSource[] params) ->
+                params.length == 1
+                && "doc-1".equals(params[0].getValue("id"))
+                && (double) params[0].getValue("importance") < 0.5
+        ));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void decay_skipsDocumentsWithInsignificantDelta() {
+        long justNow = Instant.now().minus(1, ChronoUnit.HOURS).toEpochMilli();
+        // 1 hour / 30-day half-life → delta << MIN_DELTA (0.001)
+        var candidate = new ImportanceDecayManager.DecayCandidate("doc-fresh", 0.5, justNow);
+
+        when(jdbc.query(anyString(), any(SqlParameterSource.class), any(RowMapper.class)))
+                .thenReturn(List.of(candidate));
+
+        manager.decay();
+
+        verify(jdbc, never()).batchUpdate(anyString(), any(MapSqlParameterSource[].class));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void decay_noOpsWhenNoCandidates() {
+        when(jdbc.query(anyString(), any(SqlParameterSource.class), any(RowMapper.class)))
+                .thenReturn(List.of());
+
+        manager.decay();
+
+        verify(jdbc, never()).batchUpdate(anyString(), any(MapSqlParameterSource[].class));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void decay_handlesJdbcQueryFailureGracefully() {
+        when(jdbc.query(anyString(), any(SqlParameterSource.class), any(RowMapper.class)))
+                .thenThrow(new RuntimeException("DB unreachable"));
+
+        // Should not throw
+        manager.decay();
+
+        verify(jdbc, never()).batchUpdate(anyString(), any(MapSqlParameterSource[].class));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void decay_processesMixedBatch() {
+        long oldTs   = Instant.now().minus(30, ChronoUnit.DAYS).toEpochMilli(); // needs decay
+        long freshTs = Instant.now().minus(1,  ChronoUnit.HOURS).toEpochMilli(); // skip
+
+        when(jdbc.query(anyString(), any(SqlParameterSource.class), any(RowMapper.class)))
+                .thenReturn(List.of(
+                        new ImportanceDecayManager.DecayCandidate("doc-old",   0.5, oldTs),
+                        new ImportanceDecayManager.DecayCandidate("doc-fresh", 0.5, freshTs)
+                ));
+
+        manager.decay();
+
+        // Only doc-old should be in the update batch
+        verify(jdbc).batchUpdate(anyString(), argThat((MapSqlParameterSource[] params) ->
+                params.length == 1 && "doc-old".equals(params[0].getValue("id"))
+        ));
+    }
+}

--- a/src/test/java/com/dawn/ai/memory/MemoryAccessUpdaterTest.java
+++ b/src/test/java/com/dawn/ai/memory/MemoryAccessUpdaterTest.java
@@ -1,0 +1,82 @@
+package com.dawn.ai.memory;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.ai.document.Document;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.*;
+
+class MemoryAccessUpdaterTest {
+
+    private NamedParameterJdbcTemplate jdbc;
+    private MemoryAccessUpdater updater;
+
+    @BeforeEach
+    void setUp() {
+        jdbc = mock(NamedParameterJdbcTemplate.class);
+        updater = new MemoryAccessUpdater(jdbc);
+    }
+
+    @Test
+    void updateAccessTime_updatesOnlyMemoryDocs() {
+        Document memoryDoc = new Document("mem-1", "summary text",
+                Map.of("type", "summary", "importance", 0.5));
+        Document ragDoc = new Document("rag-1", "rag chunk",
+                Map.of("source", "manual", "category", "general"));
+
+        updater.updateAccessTime(List.of(memoryDoc, ragDoc));
+
+        // Only mem-1 has 'type', so only one row in the batch
+        verify(jdbc).batchUpdate(anyString(), argThat((MapSqlParameterSource[] params) ->
+                params.length == 1 && "mem-1".equals(params[0].getValue("id"))
+        ));
+    }
+
+    @Test
+    void updateAccessTime_noOpsWhenAllRagDocs() {
+        Document ragDoc = new Document("rag-1", "chunk",
+                Map.of("source", "manual"));
+
+        updater.updateAccessTime(List.of(ragDoc));
+
+        verify(jdbc, never()).batchUpdate(anyString(), any(MapSqlParameterSource[].class));
+    }
+
+    @Test
+    void updateAccessTime_noOpsForEmptyList() {
+        updater.updateAccessTime(List.of());
+
+        verify(jdbc, never()).batchUpdate(anyString(), any(MapSqlParameterSource[].class));
+    }
+
+    @Test
+    void updateAccessTime_handlesJdbcFailureGracefully() {
+        Document memoryDoc = new Document("mem-1", "summary",
+                Map.of("type", "reflection", "importance", 0.9));
+        when(jdbc.batchUpdate(anyString(), any(MapSqlParameterSource[].class)))
+                .thenThrow(new RuntimeException("DB error"));
+
+        // Should not propagate exception
+        updater.updateAccessTime(List.of(memoryDoc));
+    }
+
+    @Test
+    void updateAccessTime_updatesMultipleMemoryDocs() {
+        Document summary   = new Document("s-1", "s", Map.of("type", "summary"));
+        Document reflection = new Document("r-1", "r", Map.of("type", "reflection"));
+        Document rag        = new Document("k-1", "k", Map.of("source", "file"));
+
+        updater.updateAccessTime(List.of(summary, reflection, rag));
+
+        verify(jdbc).batchUpdate(anyString(), argThat((MapSqlParameterSource[] params) ->
+                params.length == 2
+        ));
+    }
+}

--- a/src/test/java/com/dawn/ai/rag/RagServiceIngestUuidTest.java
+++ b/src/test/java/com/dawn/ai/rag/RagServiceIngestUuidTest.java
@@ -1,6 +1,7 @@
 package com.dawn.ai.rag;
 
 import com.dawn.ai.config.AiAvailabilityChecker;
+import com.dawn.ai.memory.MemoryAccessUpdater;
 import com.dawn.ai.rag.ingestion.OverlapTextSplitter;
 import com.dawn.ai.rag.retrieval.RetrievalRouter;
 import com.dawn.ai.rag.retrieval.fusion.ReciprocalRankFusion;
@@ -24,6 +25,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
@@ -53,7 +55,8 @@ class RagServiceIngestUuidTest {
                 new ReciprocalRankFusion(),
                 new RetrievalRouter(),
                 new OverlapTextSplitter(4, 2),
-                ragRetrievalExecutor);
+                ragRetrievalExecutor,
+                mock(MemoryAccessUpdater.class));
         ragService.initMetrics();
     }
 

--- a/src/test/java/com/dawn/ai/rag/RagServiceTest.java
+++ b/src/test/java/com/dawn/ai/rag/RagServiceTest.java
@@ -1,6 +1,7 @@
 package com.dawn.ai.rag;
 
 import com.dawn.ai.config.AiAvailabilityChecker;
+import com.dawn.ai.memory.MemoryAccessUpdater;
 import com.dawn.ai.rag.ingestion.OverlapTextSplitter;
 import com.dawn.ai.rag.retrieval.rerank.CrossEncoderRetrievalReranker;
 import com.dawn.ai.rag.retrieval.rerank.HeuristicRetrievalReranker;
@@ -58,7 +59,8 @@ class RagServiceTest {
                 new ReciprocalRankFusion(),
                 new RetrievalRouter(),
                 overlapTextSplitter,
-                ragRetrievalExecutor);
+                ragRetrievalExecutor,
+                mock(MemoryAccessUpdater.class));
         // 注入配置值（与 application.yml 一致）
         ragService.setSimilarityThreshold(0.7);
         ragService.setHybridEnabled(false);
@@ -125,7 +127,8 @@ class RagServiceTest {
                 new ReciprocalRankFusion(),
                 new RetrievalRouter(),
                 new OverlapTextSplitter(4, 2),
-                ragRetrievalExecutor);
+                ragRetrievalExecutor,
+                mock(MemoryAccessUpdater.class));
         localRagService.setSimilarityThreshold(0.7);
         localRagService.setHybridEnabled(false);
         localRagService.initMetrics();


### PR DESCRIPTION
为 AI HTTP 交互增加端到端可观测性，支持在异步线程与 Reactor 响应式管道中正确归属 sessionId。

## 变更内容

**AI 交互日志**
- `AiInteractionLogger`：将每次出站 AI 请求和入站响应以单行 JSON 格式写入独立的滚动日志文件（`ai_interaction.log`），通过自定义 logback appender 配合 `additivity=false` 与主应用日志完全隔离
- `AiInteractionController`：`GET /api/v1/ai-interactions/log?tail=N&sessionId=xxx&pretty=true` — 向前端暴露日志文件，支持按 sessionId 过滤查看

**跨线程 sessionId 传播**
Spring AI 的 tool callback 与 RAG 检索运行在不继承 Servlet 线程 `ThreadLocal` 状态的独立线程上。两个互补机制串联，确保 sessionId 在所有线程跳转中不丢失：
- `SessionAwareExecutor`：装饰 `ragRetrievalExecutor`，使每次 `CompletableFuture.supplyAsync()` 提交时捕获调用方的 sessionId，并在工作线程执行前恢复
- `AiInteractionContextAccessor`：实现 Micrometer `ThreadLocalAccessor`，配合 `Hooks.enableAutomaticContextPropagation()` 注册，使 Reactor 在流式管道的 `publishOn`/`subscribeOn` 线程切换时自动传播 sessionId

两种机制串联工作：Reactor 传播将 sessionId 带到 `boundedElastic` 线程，`SessionAwareExecutor` 再将其进一步传入 `ragRetrievalExecutor`。

**记忆管理优化**
- `ImportanceDecayManager`：基于 `lastAccessedAt` 对记忆文档重要性执行定时指数衰减——超过 `halfLifeDays` 天未被检索的文档重要性减半，使其满足被驱逐的条件
- `MemoryAccessUpdater`：检索命中时异步批量更新 `lastAccessedAt`，为衰减函数提供准确的访问时间戳

**UI**
- Chat 界面与样式优化（新增会话日志查看入口、Topic 输入联想、布局优化）
