### PR TITLE
feat(observability): 接入 Langfuse v3，拆分 metrics/observe 双 profile

### DIFF
--- a/.claude/hook-log.txt
+++ b/.claude/hook-log.txt
@@ -1,1 +1,0 @@
-2026-05-12T15:21:55Z [cc-design] session-start: fired

--- a/.env.example
+++ b/.env.example
@@ -41,3 +41,6 @@ LANGFUSE_OTLP_ENDPOINT=http://langfuse-web:3000/api/public/otel/v1/traces
 # Generate with: scripts/langfuse-auth-header.sh
 LANGFUSE_AUTH_BASE64=cGstbGYtZGF3bi1kZXY6c2stbGYtZGF3bi1kZXY=
 LANGFUSE_ENVIRONMENT=dev
+# Master switch — set to `false` when running WITHOUT `--profile observe`
+# to silence OTLP exporter warnings (turns off Spring Boot tracing entirely).
+LANGFUSE_TRACING_ENABLED=true

--- a/.env.example
+++ b/.env.example
@@ -3,7 +3,7 @@ OPENAI_API_KEY=2486
 BASE_URL=http://host.docker.internal:8000
 CHAT_MODEL=Qwen3.5-9B-MLX-4bit
 
-# oMXL - EMBEDDING MODEL 
+# oMXL - EMBEDDING MODEL
 EMBEDDING_BASE_URL=http://host.docker.internal:8000
 EMBEDDING_API_KEY=2486
 EMBEDDING_DIMENSIONS=1024
@@ -16,6 +16,10 @@ CHAT_MODEL=qwen3.6-plus
 # openrouter
 BASE_URL=https://openrouter.ai/api
 CHAT_MODEL=
+
+# mimo
+BASE_URL=https://token-plan-sgp.xiaomimimo.com
+CHAT_MODEL=mimo-v2.5-pro
 
 # ───────── Langfuse (observability) ─────────
 # Bootstrap creds — change for non-local use. langfuse-web auto-creates

--- a/.env.example
+++ b/.env.example
@@ -41,6 +41,11 @@ LANGFUSE_OTLP_ENDPOINT=http://langfuse-web:3000/api/public/otel/v1/traces
 # Generate with: scripts/langfuse-auth-header.sh
 LANGFUSE_AUTH_BASE64=cGstbGYtZGF3bi1kZXY6c2stbGYtZGF3bi1kZXY=
 LANGFUSE_ENVIRONMENT=dev
-# Master switch — set to `false` when running WITHOUT `--profile observe`
-# to silence OTLP exporter warnings (turns off Spring Boot tracing entirely).
-LANGFUSE_TRACING_ENABLED=true
+# Spring Boot 原生开关：management.tracing.enabled。
+# 注意：这是"整个 Spring Tracing 子系统"的总开关，不仅仅是 Langfuse —
+#       关掉它，所有 @Observed、所有 OTLP exporter（不限后端）都失效。
+# 默认无需在 .env 里设置：
+#   - 仅 `docker compose up -d`：主 compose 默认注入 false，避免 OTLP warn
+#   - 叠加 `-f docker-compose.observe.yml --profile observe`：overlay 覆盖为 true
+# 显式覆盖时取消下一行注释：
+# MANAGEMENT_TRACING_ENABLED=true

--- a/.env.example
+++ b/.env.example
@@ -16,3 +16,24 @@ CHAT_MODEL=qwen3.6-plus
 # openrouter
 BASE_URL=https://openrouter.ai/api
 CHAT_MODEL=
+
+# ───────── Langfuse (observability) ─────────
+# Bootstrap creds — change for non-local use. langfuse-web auto-creates
+# the org/project/user with these values on first start.
+LANGFUSE_INIT_ORG_ID=dawn-ai
+LANGFUSE_INIT_ORG_NAME=Dawn AI
+LANGFUSE_INIT_PROJECT_ID=dawn-ai
+LANGFUSE_INIT_PROJECT_NAME=dawn-ai
+LANGFUSE_INIT_PROJECT_PUBLIC_KEY=pk-lf-dawn-dev
+LANGFUSE_INIT_PROJECT_SECRET_KEY=sk-lf-dawn-dev
+LANGFUSE_INIT_USER_EMAIL=admin@dawn.local
+LANGFUSE_INIT_USER_PASSWORD=dawn-admin-123
+LANGFUSE_INIT_USER_NAME=Dawn Admin
+
+# OTLP exporter (read by dawn-ai application.yml)
+# Default endpoint targets the langfuse-web container over dawn-network.
+LANGFUSE_OTLP_ENDPOINT=http://langfuse-web:3000/api/public/otel/v1/traces
+# base64(LANGFUSE_INIT_PROJECT_PUBLIC_KEY:LANGFUSE_INIT_PROJECT_SECRET_KEY)
+# Generate with: scripts/langfuse-auth-header.sh
+LANGFUSE_AUTH_BASE64=cGstbGYtZGF3bi1kZXY6c2stbGYtZGF3bi1kZXY=
+LANGFUSE_ENVIRONMENT=dev

--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,5 @@ logs/
 .obsidian/
 
 .venv-embedding/
+
+.claude

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,14 @@ COPY --from=builder /build/target/dawn-ai-1.0.0-SNAPSHOT.jar app.jar
 
 EXPOSE 8080 5005
 
-ENV JAVA_OPTS="-Xms256m -Xmx512m -XX:+UseG1GC"
+# Container-aware heap：跟随 docker `mem_limit` 自动伸缩，无需改两处。
+#   - MaxRAMPercentage=70  →  768m 容器 → ~538m 堆，留 ~230m 给 Metaspace/CodeCache/线程栈/RSS
+#   - SerialGC：小堆（< 2 GB）下比 G1 省 ~30-50MB region 开销，dev 不关心 pause
+#   - MaxMetaspaceSize / ReservedCodeCacheSize：封顶防漏，避免 cgroup OOMKill
+#   - ExitOnOutOfMemoryError：早失败比僵尸进程更易诊断
+ENV JAVA_OPTS="-XX:MaxRAMPercentage=70 -XX:InitialRAMPercentage=20 \
+               -XX:+UseSerialGC -XX:MaxMetaspaceSize=128m \
+               -XX:ReservedCodeCacheSize=64m -XX:+ExitOnOutOfMemoryError"
 ENV JAVA_DEBUG_OPTS="-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5005"
 
 ENTRYPOINT ["sh", "-c", "java $JAVA_OPTS $JAVA_DEBUG_OPTS -jar app.jar"]

--- a/README.md
+++ b/README.md
@@ -115,25 +115,49 @@ curl "http://localhost:8080/api/v1/rag/search?query=refund+policy&topK=3"
 
 ## 📊 Observability with Langfuse
 
-`docker compose up` brings up a self-hosted **Langfuse v3** stack alongside
-the app. Every Spring AI call (chat, embedding, vector-store, tool-call)
-is exported via OTLP to Langfuse — full prompt, completion, and tool I/O
-included.
+A self-hosted **Langfuse v3** stack ships in `docker-compose.yml` behind
+the **`observe`** profile. Every Spring AI call (chat, embedding,
+vector-store, tool-call) is exported via OTLP to Langfuse — full prompt,
+completion, and tool I/O included.
 
-### First run
+### Daily dev (no Langfuse, ~2.4 GB total)
 
 ```bash
 cp .env.example .env
-# (Optional) regenerate the auth header if you change keys:
-scripts/langfuse-auth-header.sh    # paste output into LANGFUSE_AUTH_BASE64
-
-docker compose up -d
+docker compose up -d                 # business services only
 ```
 
-The first start spins up `langfuse-postgres`, `clickhouse`, `langfuse-redis`,
-`minio`, a one-shot `minio-init` (creates the `langfuse` S3 bucket), then
-`langfuse-worker` and `langfuse-web`. Wait ~60 s for `langfuse-web` to
-become healthy.
+Set `LANGFUSE_TRACING_ENABLED=false` in `.env` to suppress OTLP exporter
+warnings while no Langfuse backend is running.
+
+### When you want traces (~3.2 GB total)
+
+```bash
+# (Optional) regenerate the auth header if you changed the keys:
+scripts/langfuse-auth-header.sh      # paste into LANGFUSE_AUTH_BASE64
+# Make sure LANGFUSE_TRACING_ENABLED=true in .env
+
+docker compose --profile observe up -d
+```
+
+The `observe` profile spins up `langfuse-postgres`, `clickhouse`,
+`langfuse-redis`, `minio`, a one-shot `minio-init` (creates the
+`langfuse` S3 bucket), then `langfuse-worker` and `langfuse-web`.
+Wait ~60 s for `langfuse-web` to become healthy.
+
+### Memory budget
+
+| Container | Limit (`mem_limit`) | Notes |
+|---|---:|---|
+| langfuse-web | 640 MB | Node `--max-old-space-size=512` |
+| clickhouse | 768 MB | Custom `clickhouse/config.d/low-memory.xml` caps caches |
+| langfuse-worker | 384 MB | Node `--max-old-space-size=320` |
+| minio | 256 MB | |
+| langfuse-postgres | 192 MB | |
+| langfuse-redis | 64 MB | `--maxmemory 32mb --maxmemory-policy allkeys-lru` |
+
+Hard caps make the dev VM behave; remove them for production and let
+ClickHouse auto-size against the host.
 
 Visit **http://localhost:3001** and log in:
 
@@ -159,6 +183,6 @@ The two are independent — Langfuse downtime never affects the app.
 
 Change `LANGFUSE_INIT_PROJECT_PUBLIC_KEY` and `_SECRET_KEY` in `.env`,
 re-run `scripts/langfuse-auth-header.sh`, paste the new value into
-`LANGFUSE_AUTH_BASE64`, then `docker compose up -d --force-recreate
-langfuse-web app`.
+`LANGFUSE_AUTH_BASE64`, then `docker compose --profile observe up -d
+--force-recreate langfuse-web app`.
 

--- a/README.md
+++ b/README.md
@@ -113,76 +113,81 @@ curl "http://localhost:8080/api/v1/rag/search?query=refund+policy&topK=3"
 | `MemoryService` | Redis-backed conversation history | Circular Buffer + TTL |
 | `RagService` | Vector similarity retrieval | MySQL Index Lookup |
 
-## 📊 Observability with Langfuse
+## 📊 Observability
 
-A self-hosted **Langfuse v3** stack ships in `docker-compose.yml` behind
-the **`observe`** profile. Every Spring AI call (chat, embedding,
-vector-store, tool-call) is exported via OTLP to Langfuse — full prompt,
-completion, and tool I/O included.
+可观测能力分两条独立线，全部走 **`docker-compose.observe.yml`** overlay 文件，
+按需 opt-in，互不依赖：
 
-### Daily dev (no Langfuse, ~2.4 GB total)
+| Profile | 启动的容器 | 用途 | UI |
+|---|---|---|---|
+| `--profile metrics` | `prometheus` + `grafana` | JVM / HTTP / 业务指标 | http://localhost:3000 |
+| `--profile observe` | `langfuse-*` + `clickhouse` + `minio` 等 7 个 | LLM trace / prompt / tool I/O | http://localhost:3001 |
 
-```bash
-cp .env.example .env
-docker compose up -d                 # business services only
-```
-
-Set `LANGFUSE_TRACING_ENABLED=false` in `.env` to suppress OTLP exporter
-warnings while no Langfuse backend is running.
-
-### When you want traces (~3.2 GB total)
+### 启动命令矩阵
 
 ```bash
-# (Optional) regenerate the auth header if you changed the keys:
-scripts/langfuse-auth-header.sh      # paste into LANGFUSE_AUTH_BASE64
-# Make sure LANGFUSE_TRACING_ENABLED=true in .env
+# 业务最小（仅 app + postgres + redis，~1.1 GB）
+docker compose up -d
 
-docker compose --profile observe up -d
+# + 监控
+docker compose -f docker-compose.yml -f docker-compose.observe.yml --profile metrics up -d
+
+# + Langfuse（首次启动等 ~60s 让 langfuse-web 健康）
+docker compose -f docker-compose.yml -f docker-compose.observe.yml --profile observe up -d
+
+# 全开
+docker compose -f docker-compose.yml -f docker-compose.observe.yml \
+  --profile metrics --profile observe up -d
 ```
 
-The `observe` profile spins up `langfuse-postgres`, `clickhouse`,
-`langfuse-redis`, `minio`, a one-shot `minio-init` (creates the
-`langfuse` S3 bucket), then `langfuse-worker` and `langfuse-web`.
-Wait ~60 s for `langfuse-web` to become healthy.
+> **Tracing 总开关**：`MANAGEMENT_TRACING_ENABLED`（Spring Boot 原生 `management.tracing.enabled`）。
+> 主 compose 默认 `false`；叠加 `-f docker-compose.observe.yml` 时 overlay 会把它覆盖为 `true`。
+> 想强制覆盖时在 `.env` 里设置即可。⚠️ 这是整个 Spring Tracing 子系统的开关，
+> 关掉它所有 `@Observed` 和 OTLP exporter（不限后端）都会失效。
+>
+> **Corner case**：单用 `--profile metrics`（叠加了 overlay 但没启 langfuse-web）时
+> tracing 仍被自动开为 `true`，会持续 OTLP warn。此时在 `.env` 里显式
+> `MANAGEMENT_TRACING_ENABLED=false` 静默即可。
 
-### Memory budget
+### 内存预算
 
-| Container | Limit (`mem_limit`) | Notes |
+| 容器 | mem_limit | 备注 |
 |---|---:|---|
-| langfuse-web | 640 MB | Node `--max-old-space-size=512` |
-| clickhouse | 768 MB | Custom `clickhouse/config.d/low-memory.xml` caps caches |
-| langfuse-worker | 384 MB | Node `--max-old-space-size=320` |
-| minio | 256 MB | |
-| langfuse-postgres | 192 MB | |
-| langfuse-redis | 64 MB | `--maxmemory 32mb --maxmemory-policy allkeys-lru` |
+| **app** | 768 MB | JVM `MaxRAMPercentage=70` + SerialGC |
+| postgres | 256 MB | `shared_buffers=64MB max_connections=50` |
+| redis | 96 MB | `maxmemory 48mb allkeys-lru` |
+| prometheus | 192 MB | metrics profile |
+| grafana | 256 MB | metrics profile |
+| langfuse-web | 480 MB | Node `--max-old-space-size=384` |
+| clickhouse | 700 MB | `clickhouse/config.d/low-memory.xml` 收紧 caches |
+| langfuse-worker | 320 MB | Node `--max-old-space-size=256` |
+| langfuse-postgres | 320 MB | observe profile |
+| minio | 256 MB | observe profile |
+| langfuse-redis | 64 MB | `maxmemory 32mb` |
 
-Hard caps make the dev VM behave; remove them for production and let
-ClickHouse auto-size against the host.
+业务 ≈ 1.1 GB；+metrics ≈ 1.6 GB；+observe ≈ 3.3 GB；全开 ≈ 3.7 GB。
+生产环境删 `mem_limit` 让 ClickHouse 等组件自适应宿主机。
 
-Visit **http://localhost:3001** and log in:
+### Langfuse 登录
+
+Visit **http://localhost:3001**：
 
 | Field | Value (defaults from `.env.example`) |
 |---|---|
 | Email | `admin@dawn.local` |
 | Password | `dawn-admin-123` |
 
-The `dawn-ai` project is auto-created. New chats appear under **Tracing**
-within seconds; the **Sessions** tab groups traces by the `sessionId` you
-pass in the chat request body.
-
-### What goes where
-
-| Stack | Purpose | UI |
-|---|---|---|
-| **Prometheus + Grafana** (existing) | Aggregate metrics, RED, SLOs | http://localhost:3000 |
-| **Langfuse** (new) | Per-request traces, prompts, tool I/O | http://localhost:3001 |
-
-The two are independent — Langfuse downtime never affects the app.
+`dawn-ai` 项目自动创建。新会话几秒后出现在 **Tracing**；**Sessions** 标签按
+你传入的 `sessionId` 聚合。
 
 ### Rotating keys / production
 
 Change `LANGFUSE_INIT_PROJECT_PUBLIC_KEY` and `_SECRET_KEY` in `.env`,
 re-run `scripts/langfuse-auth-header.sh`, paste the new value into
-`LANGFUSE_AUTH_BASE64`, then `docker compose --profile observe up -d
---force-recreate langfuse-web app`.
+`LANGFUSE_AUTH_BASE64`, then:
+
+```bash
+docker compose -f docker-compose.yml -f docker-compose.observe.yml \
+  --profile observe up -d --force-recreate langfuse-web app
+```
 

--- a/README.md
+++ b/README.md
@@ -113,7 +113,52 @@ curl "http://localhost:8080/api/v1/rag/search?query=refund+policy&topK=3"
 | `MemoryService` | Redis-backed conversation history | Circular Buffer + TTL |
 | `RagService` | Vector similarity retrieval | MySQL Index Lookup |
 
+## 📊 Observability with Langfuse
 
+`docker compose up` brings up a self-hosted **Langfuse v3** stack alongside
+the app. Every Spring AI call (chat, embedding, vector-store, tool-call)
+is exported via OTLP to Langfuse — full prompt, completion, and tool I/O
+included.
 
+### First run
 
+```bash
+cp .env.example .env
+# (Optional) regenerate the auth header if you change keys:
+scripts/langfuse-auth-header.sh    # paste output into LANGFUSE_AUTH_BASE64
+
+docker compose up -d
+```
+
+The first start spins up `langfuse-postgres`, `clickhouse`, `langfuse-redis`,
+`minio`, a one-shot `minio-init` (creates the `langfuse` S3 bucket), then
+`langfuse-worker` and `langfuse-web`. Wait ~60 s for `langfuse-web` to
+become healthy.
+
+Visit **http://localhost:3001** and log in:
+
+| Field | Value (defaults from `.env.example`) |
+|---|---|
+| Email | `admin@dawn.local` |
+| Password | `dawn-admin-123` |
+
+The `dawn-ai` project is auto-created. New chats appear under **Tracing**
+within seconds; the **Sessions** tab groups traces by the `sessionId` you
+pass in the chat request body.
+
+### What goes where
+
+| Stack | Purpose | UI |
+|---|---|---|
+| **Prometheus + Grafana** (existing) | Aggregate metrics, RED, SLOs | http://localhost:3000 |
+| **Langfuse** (new) | Per-request traces, prompts, tool I/O | http://localhost:3001 |
+
+The two are independent — Langfuse downtime never affects the app.
+
+### Rotating keys / production
+
+Change `LANGFUSE_INIT_PROJECT_PUBLIC_KEY` and `_SECRET_KEY` in `.env`,
+re-run `scripts/langfuse-auth-header.sh`, paste the new value into
+`LANGFUSE_AUTH_BASE64`, then `docker compose up -d --force-recreate
+langfuse-web app`.
 

--- a/clickhouse/config.d/low-memory.xml
+++ b/clickhouse/config.d/low-memory.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0"?>
+<!--
+  Tight memory caps for local-dev. Production should remove this file
+  and let ClickHouse auto-size against the host.
+    - max_server_memory_usage: hard ceiling, 512 MiB
+    - mark_cache_size:         128 MiB (default ~5 GiB)
+    - uncompressed_cache_size: disabled (Langfuse trace queries don't reuse blocks much)
+    - max_concurrent_queries:  16 (default 100)
+  NOTE: do NOT lower background_pool_size — it conflicts with ClickHouse's
+  mutation pool sanity check (number_of_free_entries_in_pool_to_execute_mutation
+  defaults to 20 and must be ≤ background_pool_size * mutations_concurrency_ratio).
+-->
+<clickhouse>
+    <max_server_memory_usage>536870912</max_server_memory_usage>
+    <mark_cache_size>134217728</mark_cache_size>
+    <uncompressed_cache_size>0</uncompressed_cache_size>
+    <max_concurrent_queries>16</max_concurrent_queries>
+    <!-- Force IPv4 listen. Docker default network often has IPv6 disabled,
+         which makes the default `[::]:9000` listen silently fail and
+         langfuse-web's clickhouse migration step hits "connection refused". -->
+    <listen_host>0.0.0.0</listen_host>
+</clickhouse>

--- a/clickhouse/config.d/low-memory.xml
+++ b/clickhouse/config.d/low-memory.xml
@@ -2,19 +2,23 @@
 <!--
   Tight memory caps for local-dev. Production should remove this file
   and let ClickHouse auto-size against the host.
-    - max_server_memory_usage: hard ceiling, 512 MiB
-    - mark_cache_size:         128 MiB (default ~5 GiB)
-    - uncompressed_cache_size: disabled (Langfuse trace queries don't reuse blocks much)
-    - max_concurrent_queries:  16 (default 100)
+    - max_server_memory_usage:  hard ceiling, 512 MiB
+    - mark_cache_size:          128 MiB (default ~5 GiB)
+    - uncompressed_cache_size:  disabled (Langfuse trace queries don't reuse blocks much)
+    - max_concurrent_queries:   16   (default 100)
+    - max_thread_pool_size:     200  (default 10000) — caps lazy thread allocation
+    - max_server_memory_usage_to_ram_ratio: 0.85 — soft buffer below the hard cap
   NOTE: do NOT lower background_pool_size — it conflicts with ClickHouse's
   mutation pool sanity check (number_of_free_entries_in_pool_to_execute_mutation
   defaults to 20 and must be ≤ background_pool_size * mutations_concurrency_ratio).
 -->
 <clickhouse>
     <max_server_memory_usage>536870912</max_server_memory_usage>
+    <max_server_memory_usage_to_ram_ratio>0.85</max_server_memory_usage_to_ram_ratio>
     <mark_cache_size>134217728</mark_cache_size>
     <uncompressed_cache_size>0</uncompressed_cache_size>
     <max_concurrent_queries>16</max_concurrent_queries>
+    <max_thread_pool_size>200</max_thread_pool_size>
     <!-- Force IPv4 listen. Docker default network often has IPv6 disabled,
          which makes the default `[::]:9000` listen silently fail and
          langfuse-web's clickhouse migration step hits "connection refused". -->

--- a/docker-compose.observe.yml
+++ b/docker-compose.observe.yml
@@ -1,0 +1,272 @@
+# docker-compose.observe.yml
+# 可观测能力 overlay —— 全部 opt-in，无副作用。
+#
+# 两个独立 profile：
+#   --profile metrics  → Prometheus + Grafana（基础设施 / JVM / HTTP 指标）
+#   --profile observe  → Langfuse 全家桶（LLM trace / prompt / tool I/O）
+#
+# 用法（与主 compose 叠加）：
+#   docker compose -f docker-compose.yml -f docker-compose.observe.yml --profile metrics up -d
+#   docker compose -f docker-compose.yml -f docker-compose.observe.yml --profile observe up -d
+#   docker compose -f docker-compose.yml -f docker-compose.observe.yml --profile metrics --profile observe up -d
+#
+# 关闭：同样的 -f / --profile 组合后跟 `down`。
+#
+# 内存预算（dev 单租户，Mac 24GB）：
+#   metrics profile：prometheus 192m + grafana 256m ≈ 448 MB
+#   observe profile：langfuse-postgres 320 + langfuse-redis 64 + clickhouse 700
+#                    + minio 256 + langfuse-worker 320 + langfuse-web 480 ≈ 2.14 GB
+
+services:
+  # ─── 覆盖主 compose 的 app：observe profile 启用时强制 tracing=true ──
+  # service-merge 时，environment mapping 的同名 key 会覆盖主文件 list 中的值；
+  # 没有 observe 服务被启动时（仅 --profile metrics），该覆盖无副作用。
+  app:
+    environment:
+      MANAGEMENT_TRACING_ENABLED: "${MANAGEMENT_TRACING_ENABLED:-true}"
+
+  # ───────── metrics profile ─────────
+  prometheus:
+    image: prom/prometheus:v3.2.1
+    profiles: ["metrics"]
+    restart: unless-stopped
+    mem_limit: 192m
+    mem_reservation: 96m
+    ports:
+      - "9090:9090"
+    volumes:
+      - ./prometheus.yml:/etc/prometheus/prometheus.yml
+    networks:
+      - dawn-network
+
+  grafana:
+    image: grafana/grafana:11.5.2
+    profiles: ["metrics"]
+    restart: unless-stopped
+    mem_limit: 256m
+    mem_reservation: 128m
+    ports:
+      - "3000:3000"
+    environment:
+      - GF_SECURITY_ADMIN_PASSWORD=admin123
+    volumes:
+      - grafana_data:/var/lib/grafana
+      - ./grafana/provisioning:/etc/grafana/provisioning
+      - ./grafana/dashboards:/var/lib/grafana/dashboards
+    networks:
+      - dawn-network
+
+  # ───────── observe profile (Langfuse v3) ─────────
+  langfuse-postgres:
+    image: postgres:16-alpine
+    profiles: ["observe"]
+    restart: unless-stopped
+    mem_limit: 320m
+    mem_reservation: 192m
+    command: >
+      postgres -c shared_buffers=96MB
+               -c max_connections=50
+               -c effective_cache_size=192MB
+               -c work_mem=4MB
+    environment:
+      POSTGRES_USER: langfuse
+      POSTGRES_PASSWORD: langfuse123
+      POSTGRES_DB: langfuse
+    volumes:
+      - langfuse_postgres_data:/var/lib/postgresql/data
+    ports:
+      - "5433:5432"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U langfuse -d langfuse"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+    networks:
+      - dawn-network
+
+  langfuse-redis:
+    image: redis:7-alpine
+    profiles: ["observe"]
+    restart: unless-stopped
+    mem_limit: 64m
+    mem_reservation: 32m
+    command: redis-server --appendonly yes --requirepass langfuse123 --maxmemory 32mb --maxmemory-policy allkeys-lru
+    volumes:
+      - langfuse_redis_data:/data
+    healthcheck:
+      test: ["CMD", "redis-cli", "-a", "langfuse123", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+    networks:
+      - dawn-network
+
+  clickhouse:
+    image: clickhouse/clickhouse-server:24.3
+    profiles: ["observe"]
+    restart: unless-stopped
+    mem_limit: 700m
+    mem_reservation: 512m
+    environment:
+      CLICKHOUSE_USER: clickhouse
+      CLICKHOUSE_PASSWORD: clickhouse123
+      CLICKHOUSE_DB: default
+    volumes:
+      - clickhouse_data:/var/lib/clickhouse
+      - ./clickhouse/config.d:/etc/clickhouse-server/config.d:ro
+    ulimits:
+      nofile:
+        soft: 262144
+        hard: 262144
+    healthcheck:
+      test: ["CMD-SHELL", "clickhouse-client --user clickhouse --password clickhouse123 --query 'SELECT 1' || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+    networks:
+      - dawn-network
+
+  minio:
+    image: minio/minio:latest
+    profiles: ["observe"]
+    restart: unless-stopped
+    mem_limit: 256m
+    mem_reservation: 128m
+    command: server --address ":9000" --console-address ":9001" /data
+    environment:
+      MINIO_ROOT_USER: minio
+      MINIO_ROOT_PASSWORD: minio12345
+    volumes:
+      - minio_data:/data
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+    networks:
+      - dawn-network
+
+  # One-shot bucket creator. Langfuse v3 writes OTLP events to S3,
+  # so the `langfuse` bucket must exist before ingestion succeeds.
+  minio-init:
+    image: minio/mc:latest
+    profiles: ["observe"]
+    depends_on:
+      minio: { condition: service_healthy }
+    restart: "no"
+    entrypoint: >
+      /bin/sh -c "
+      mc alias set local http://minio:9000 minio minio12345 &&
+      mc mb -p local/langfuse || true &&
+      echo 'minio bucket ready'
+      "
+    networks:
+      - dawn-network
+
+  langfuse-worker:
+    image: langfuse/langfuse-worker:3
+    profiles: ["observe"]
+    restart: unless-stopped
+    mem_limit: 320m
+    mem_reservation: 192m
+    depends_on:
+      langfuse-postgres: { condition: service_healthy }
+      langfuse-redis:    { condition: service_healthy }
+      clickhouse:        { condition: service_healthy }
+      minio:             { condition: service_healthy }
+      minio-init:        { condition: service_completed_successfully }
+    environment:
+      NODE_OPTIONS: "--max-old-space-size=256"
+      DATABASE_URL: postgresql://langfuse:langfuse123@langfuse-postgres:5432/langfuse
+      SALT: "dawn-langfuse-salt-change-me"
+      ENCRYPTION_KEY: "0000000000000000000000000000000000000000000000000000000000000000"
+      TELEMETRY_ENABLED: "false"
+      CLICKHOUSE_URL: http://clickhouse:8123
+      CLICKHOUSE_MIGRATION_URL: clickhouse://clickhouse:9000
+      CLICKHOUSE_USER: clickhouse
+      CLICKHOUSE_PASSWORD: clickhouse123
+      CLICKHOUSE_CLUSTER_ENABLED: "false"
+      LANGFUSE_S3_EVENT_UPLOAD_BUCKET: langfuse
+      LANGFUSE_S3_EVENT_UPLOAD_REGION: auto
+      LANGFUSE_S3_EVENT_UPLOAD_ACCESS_KEY_ID: minio
+      LANGFUSE_S3_EVENT_UPLOAD_SECRET_ACCESS_KEY: minio12345
+      LANGFUSE_S3_EVENT_UPLOAD_ENDPOINT: http://minio:9000
+      LANGFUSE_S3_EVENT_UPLOAD_FORCE_PATH_STYLE: "true"
+      LANGFUSE_S3_EVENT_UPLOAD_PREFIX: "events/"
+      REDIS_HOST: langfuse-redis
+      REDIS_PORT: 6379
+      REDIS_AUTH: langfuse123
+      # Allow LLM connections to host-machine services (e.g. oMLX via host.docker.internal)
+      # Ref: https://github.com/langfuse/langfuse/pull/13073
+      LANGFUSE_LLM_CONNECTION_WHITELISTED_HOST: host.docker.internal
+    networks:
+      - dawn-network
+
+  langfuse-web:
+    image: langfuse/langfuse:3
+    profiles: ["observe"]
+    restart: unless-stopped
+    mem_limit: 480m
+    mem_reservation: 320m
+    depends_on:
+      langfuse-postgres: { condition: service_healthy }
+      langfuse-redis:    { condition: service_healthy }
+      clickhouse:        { condition: service_healthy }
+      minio:             { condition: service_healthy }
+      minio-init:        { condition: service_completed_successfully }
+    ports:
+      - "3001:3000"
+    environment:
+      NODE_OPTIONS: "--max-old-space-size=384"
+      DATABASE_URL: postgresql://langfuse:langfuse123@langfuse-postgres:5432/langfuse
+      NEXTAUTH_URL: http://localhost:3001
+      NEXTAUTH_SECRET: "dawn-langfuse-nextauth-secret-change-me"
+      SALT: "dawn-langfuse-salt-change-me"
+      ENCRYPTION_KEY: "0000000000000000000000000000000000000000000000000000000000000000"
+      TELEMETRY_ENABLED: "false"
+      CLICKHOUSE_URL: http://clickhouse:8123
+      CLICKHOUSE_MIGRATION_URL: clickhouse://clickhouse:9000
+      CLICKHOUSE_USER: clickhouse
+      CLICKHOUSE_PASSWORD: clickhouse123
+      CLICKHOUSE_CLUSTER_ENABLED: "false"
+      LANGFUSE_S3_EVENT_UPLOAD_BUCKET: langfuse
+      LANGFUSE_S3_EVENT_UPLOAD_REGION: auto
+      LANGFUSE_S3_EVENT_UPLOAD_ACCESS_KEY_ID: minio
+      LANGFUSE_S3_EVENT_UPLOAD_SECRET_ACCESS_KEY: minio12345
+      LANGFUSE_S3_EVENT_UPLOAD_ENDPOINT: http://minio:9000
+      LANGFUSE_S3_EVENT_UPLOAD_FORCE_PATH_STYLE: "true"
+      LANGFUSE_S3_EVENT_UPLOAD_PREFIX: "events/"
+      REDIS_HOST: langfuse-redis
+      REDIS_PORT: 6379
+      REDIS_AUTH: langfuse123
+      LANGFUSE_INIT_ORG_ID: ${LANGFUSE_INIT_ORG_ID:-dawn-ai}
+      LANGFUSE_INIT_ORG_NAME: ${LANGFUSE_INIT_ORG_NAME:-Dawn AI}
+      LANGFUSE_INIT_PROJECT_ID: ${LANGFUSE_INIT_PROJECT_ID:-dawn-ai}
+      LANGFUSE_INIT_PROJECT_NAME: ${LANGFUSE_INIT_PROJECT_NAME:-dawn-ai}
+      LANGFUSE_INIT_PROJECT_PUBLIC_KEY: ${LANGFUSE_INIT_PROJECT_PUBLIC_KEY:-pk-lf-dawn-dev}
+      LANGFUSE_INIT_PROJECT_SECRET_KEY: ${LANGFUSE_INIT_PROJECT_SECRET_KEY:-sk-lf-dawn-dev}
+      LANGFUSE_INIT_USER_EMAIL: ${LANGFUSE_INIT_USER_EMAIL:-admin@dawn.local}
+      LANGFUSE_INIT_USER_PASSWORD: ${LANGFUSE_INIT_USER_PASSWORD:-dawn-admin-123}
+      LANGFUSE_INIT_USER_NAME: ${LANGFUSE_INIT_USER_NAME:-Dawn Admin}
+      # Allow LLM connections to host-machine services (e.g. oMLX via host.docker.internal)
+      # Ref: https://github.com/langfuse/langfuse/pull/13073
+      LANGFUSE_LLM_CONNECTION_WHITELISTED_HOST: host.docker.internal
+    healthcheck:
+      test: ["CMD", "wget", "-q", "--spider", "http://localhost:3000/api/public/health"]
+      interval: 15s
+      timeout: 5s
+      retries: 20
+      start_period: 60s
+    networks:
+      - dawn-network
+
+volumes:
+  grafana_data:
+  langfuse_postgres_data:
+  langfuse_redis_data:
+  clickhouse_data:
+  minio_data:
+
+networks:
+  dawn-network:
+    driver: bridge

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -244,6 +244,9 @@ services:
       REDIS_HOST: langfuse-redis
       REDIS_PORT: 6379
       REDIS_AUTH: langfuse123
+      # Allow LLM connections to host-machine services (e.g. oMLX via host.docker.internal)
+      # Ref: https://github.com/langfuse/langfuse/pull/13073
+      LANGFUSE_LLM_CONNECTION_WHITELISTED_HOST: host.docker.internal
     networks:
       - dawn-network
 
@@ -292,6 +295,9 @@ services:
       LANGFUSE_INIT_USER_EMAIL: ${LANGFUSE_INIT_USER_EMAIL:-admin@dawn.local}
       LANGFUSE_INIT_USER_PASSWORD: ${LANGFUSE_INIT_USER_PASSWORD:-dawn-admin-123}
       LANGFUSE_INIT_USER_NAME: ${LANGFUSE_INIT_USER_NAME:-Dawn Admin}
+      # Allow LLM connections to host-machine services (e.g. oMLX via host.docker.internal)
+      # Ref: https://github.com/langfuse/langfuse/pull/13073
+      LANGFUSE_LLM_CONNECTION_WHITELISTED_HOST: host.docker.internal
     healthcheck:
       test: ["CMD", "wget", "-q", "--spider", "http://localhost:3000/api/public/health"]
       interval: 15s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -179,6 +179,22 @@ services:
     networks:
       - dawn-network
 
+  # One-shot bucket creator. Langfuse v3 writes OTLP events to S3,
+  # so the `langfuse` bucket must exist before ingestion succeeds.
+  minio-init:
+    image: minio/mc:latest
+    depends_on:
+      minio: { condition: service_healthy }
+    restart: "no"
+    entrypoint: >
+      /bin/sh -c "
+      mc alias set local http://minio:9000 minio minio12345 &&
+      mc mb -p local/langfuse || true &&
+      echo 'minio bucket ready'
+      "
+    networks:
+      - dawn-network
+
   langfuse-worker:
     image: langfuse/langfuse-worker:3
     restart: unless-stopped
@@ -187,6 +203,7 @@ services:
       langfuse-redis:    { condition: service_healthy }
       clickhouse:        { condition: service_healthy }
       minio:             { condition: service_healthy }
+      minio-init:        { condition: service_completed_successfully }
     environment:
       DATABASE_URL: postgresql://langfuse:langfuse123@langfuse-postgres:5432/langfuse
       SALT: "dawn-langfuse-salt-change-me"
@@ -218,6 +235,7 @@ services:
       langfuse-redis:    { condition: service_healthy }
       clickhouse:        { condition: service_healthy }
       minio:             { condition: service_healthy }
+      minio-init:        { condition: service_completed_successfully }
     ports:
       - "3001:3000"
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,6 +32,9 @@ services:
       - SPRING_DATASOURCE_USERNAME=dawn
       - SPRING_DATASOURCE_PASSWORD=dawn123
       - SPRING_DATA_REDIS_HOST=redis
+      - LANGFUSE_OTLP_ENDPOINT=${LANGFUSE_OTLP_ENDPOINT:-http://langfuse-web:3000/api/public/otel/v1/traces}
+      - LANGFUSE_AUTH_BASE64=${LANGFUSE_AUTH_BASE64}
+      - LANGFUSE_ENVIRONMENT=${LANGFUSE_ENVIRONMENT:-dev}
     depends_on:
       postgres:
         condition: service_healthy

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,14 +1,23 @@
 # docker-compose.yml
-# Apple Silicon 本地开发 override：
+# Apple Silicon 本地开发：
 #   - embedding 服务由宿主机原生脚本提供（Metal GPU / MPS），不在容器中运行
-#   - 其余服务（postgres / redis / prometheus / grafana / app）保持 Docker 不变
+#   - 业务侧默认启动：app / postgres / redis（最小内存占用，~1.1 GB）
+#   - 可观测能力全部移到 docker-compose.observe.yml，按需 opt-in：
+#       --profile metrics  → Prometheus + Grafana
+#       --profile observe  → Langfuse 全家桶
 #
 # 启动步骤：
 #   1. ./scripts/start-embedding-mac.sh --daemon
 #   2. docker compose up -d
+#                                                                            # 业务（最小）
+#   3. docker compose -f docker-compose.yml -f docker-compose.observe.yml --profile metrics up -d
+#                                                                            # + Prometheus/Grafana
+#   4. docker compose -f docker-compose.yml -f docker-compose.observe.yml --profile observe up -d
+#                                                                            # + Langfuse 全家桶
+#   5. 全开：上一行再追加 `--profile metrics`
 #
 # 停止：
-#   docker compose down
+#   docker compose [上述同样的 -f / --profile 组合] down
 #   ./scripts/stop-embedding-mac.sh
 
 services:
@@ -17,6 +26,8 @@ services:
       context: .
       dockerfile: Dockerfile
     restart: unless-stopped
+    mem_limit: 768m
+    mem_reservation: 384m
     ports:
       - "8080:8080"
       - "5005:5005"
@@ -35,25 +46,28 @@ services:
       - LANGFUSE_OTLP_ENDPOINT=${LANGFUSE_OTLP_ENDPOINT:-http://langfuse-web:3000/api/public/otel/v1/traces}
       - LANGFUSE_AUTH_BASE64=${LANGFUSE_AUTH_BASE64}
       - LANGFUSE_ENVIRONMENT=${LANGFUSE_ENVIRONMENT:-dev}
-      # Set to false (or to `LANGFUSE_TRACING_ENABLED=false` in .env) when
-      # running without the `observe` profile, to silence OTLP exporter warns.
-      - MANAGEMENT_TRACING_ENABLED=${LANGFUSE_TRACING_ENABLED:-true}
+      # Spring Boot 原生开关 management.tracing.enabled。
+      # 业务单独跑时默认 false，避免 OTLP exporter 找不到 langfuse-web 持续 warn。
+      # 叠加 docker-compose.observe.yml 时会被覆盖为 true（见 overlay 文件）。
+      - MANAGEMENT_TRACING_ENABLED=${MANAGEMENT_TRACING_ENABLED:-false}
     depends_on:
       postgres:
         condition: service_healthy
       redis:
         condition: service_healthy
-      prometheus:
-        condition: service_started
-      grafana:
-        condition: service_started
     networks:
       - dawn-network
-
 
   postgres:
     image: pgvector/pgvector:0.8.0-pg16
     restart: unless-stopped
+    mem_limit: 256m
+    mem_reservation: 128m
+    command: >
+      postgres -c shared_buffers=64MB
+               -c max_connections=50
+               -c effective_cache_size=128MB
+               -c work_mem=4MB
     environment:
       POSTGRES_DB: dawn_ai
       POSTGRES_USER: dawn
@@ -73,11 +87,13 @@ services:
   redis:
     image: redis:7
     restart: unless-stopped
+    mem_limit: 96m
+    mem_reservation: 32m
     ports:
       - "6379:6379"
     volumes:
       - redis_data:/data
-    command: redis-server --appendonly yes
+    command: redis-server --appendonly yes --maxmemory 48mb --maxmemory-policy allkeys-lru
     healthcheck:
       test: ["CMD", "redis-cli", "ping"]
       interval: 10s
@@ -86,236 +102,10 @@ services:
     networks:
       - dawn-network
 
-  prometheus:
-    image: prom/prometheus:v3.2.1
-    restart: unless-stopped
-    ports:
-      - "9090:9090"
-    volumes:
-      - ./prometheus.yml:/etc/prometheus/prometheus.yml
-    networks:
-      - dawn-network
-
-  grafana:
-    image: grafana/grafana:11.5.2
-    restart: unless-stopped
-    ports:
-      - "3000:3000"
-    environment:
-      - GF_SECURITY_ADMIN_PASSWORD=admin123
-    volumes:
-      - grafana_data:/var/lib/grafana
-      - ./grafana/provisioning:/etc/grafana/provisioning
-      - ./grafana/dashboards:/var/lib/grafana/dashboards
-    networks:
-      - dawn-network
-
-  # ───────── Langfuse v3 (LLM observability, opt-in profile) ─────────
-  # All services below are gated by `profiles: ["observe"]`. Daily dev:
-  #   docker compose up -d                    # business only, no Langfuse
-  # When you want traces:
-  #   docker compose --profile observe up -d  # adds the full Langfuse stack
-  langfuse-postgres:
-    image: postgres:16-alpine
-    profiles: ["observe"]
-    restart: unless-stopped
-    mem_limit: 192m
-    environment:
-      POSTGRES_USER: langfuse
-      POSTGRES_PASSWORD: langfuse123
-      POSTGRES_DB: langfuse
-    volumes:
-      - langfuse_postgres_data:/var/lib/postgresql/data
-    ports:
-      - "5433:5432"
-    healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U langfuse -d langfuse"]
-      interval: 10s
-      timeout: 5s
-      retries: 10
-    networks:
-      - dawn-network
-
-  langfuse-redis:
-    image: redis:7-alpine
-    profiles: ["observe"]
-    restart: unless-stopped
-    mem_limit: 64m
-    command: redis-server --appendonly yes --requirepass langfuse123 --maxmemory 32mb --maxmemory-policy allkeys-lru
-    volumes:
-      - langfuse_redis_data:/data
-    healthcheck:
-      test: ["CMD", "redis-cli", "-a", "langfuse123", "ping"]
-      interval: 10s
-      timeout: 5s
-      retries: 10
-    networks:
-      - dawn-network
-
-  clickhouse:
-    image: clickhouse/clickhouse-server:24.3
-    profiles: ["observe"]
-    restart: unless-stopped
-    mem_limit: 768m
-    environment:
-      CLICKHOUSE_USER: clickhouse
-      CLICKHOUSE_PASSWORD: clickhouse123
-      CLICKHOUSE_DB: default
-    volumes:
-      - clickhouse_data:/var/lib/clickhouse
-      - ./clickhouse/config.d:/etc/clickhouse-server/config.d:ro
-    ulimits:
-      nofile:
-        soft: 262144
-        hard: 262144
-    healthcheck:
-      test: ["CMD-SHELL", "clickhouse-client --user clickhouse --password clickhouse123 --query 'SELECT 1' || exit 1"]
-      interval: 10s
-      timeout: 5s
-      retries: 10
-    networks:
-      - dawn-network
-
-  minio:
-    image: minio/minio:latest
-    profiles: ["observe"]
-    restart: unless-stopped
-    mem_limit: 256m
-    command: server --address ":9000" --console-address ":9001" /data
-    environment:
-      MINIO_ROOT_USER: minio
-      MINIO_ROOT_PASSWORD: minio12345
-    volumes:
-      - minio_data:/data
-    healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
-      interval: 10s
-      timeout: 5s
-      retries: 10
-    networks:
-      - dawn-network
-
-  # One-shot bucket creator. Langfuse v3 writes OTLP events to S3,
-  # so the `langfuse` bucket must exist before ingestion succeeds.
-  minio-init:
-    image: minio/mc:latest
-    profiles: ["observe"]
-    depends_on:
-      minio: { condition: service_healthy }
-    restart: "no"
-    entrypoint: >
-      /bin/sh -c "
-      mc alias set local http://minio:9000 minio minio12345 &&
-      mc mb -p local/langfuse || true &&
-      echo 'minio bucket ready'
-      "
-    networks:
-      - dawn-network
-
-  langfuse-worker:
-    image: langfuse/langfuse-worker:3
-    profiles: ["observe"]
-    restart: unless-stopped
-    mem_limit: 384m
-    depends_on:
-      langfuse-postgres: { condition: service_healthy }
-      langfuse-redis:    { condition: service_healthy }
-      clickhouse:        { condition: service_healthy }
-      minio:             { condition: service_healthy }
-      minio-init:        { condition: service_completed_successfully }
-    environment:
-      NODE_OPTIONS: "--max-old-space-size=320"
-      DATABASE_URL: postgresql://langfuse:langfuse123@langfuse-postgres:5432/langfuse
-      SALT: "dawn-langfuse-salt-change-me"
-      ENCRYPTION_KEY: "0000000000000000000000000000000000000000000000000000000000000000"
-      TELEMETRY_ENABLED: "false"
-      CLICKHOUSE_URL: http://clickhouse:8123
-      CLICKHOUSE_MIGRATION_URL: clickhouse://clickhouse:9000
-      CLICKHOUSE_USER: clickhouse
-      CLICKHOUSE_PASSWORD: clickhouse123
-      CLICKHOUSE_CLUSTER_ENABLED: "false"
-      LANGFUSE_S3_EVENT_UPLOAD_BUCKET: langfuse
-      LANGFUSE_S3_EVENT_UPLOAD_REGION: auto
-      LANGFUSE_S3_EVENT_UPLOAD_ACCESS_KEY_ID: minio
-      LANGFUSE_S3_EVENT_UPLOAD_SECRET_ACCESS_KEY: minio12345
-      LANGFUSE_S3_EVENT_UPLOAD_ENDPOINT: http://minio:9000
-      LANGFUSE_S3_EVENT_UPLOAD_FORCE_PATH_STYLE: "true"
-      LANGFUSE_S3_EVENT_UPLOAD_PREFIX: "events/"
-      REDIS_HOST: langfuse-redis
-      REDIS_PORT: 6379
-      REDIS_AUTH: langfuse123
-      # Allow LLM connections to host-machine services (e.g. oMLX via host.docker.internal)
-      # Ref: https://github.com/langfuse/langfuse/pull/13073
-      LANGFUSE_LLM_CONNECTION_WHITELISTED_HOST: host.docker.internal
-    networks:
-      - dawn-network
-
-  langfuse-web:
-    image: langfuse/langfuse:3
-    profiles: ["observe"]
-    restart: unless-stopped
-    mem_limit: 640m
-    depends_on:
-      langfuse-postgres: { condition: service_healthy }
-      langfuse-redis:    { condition: service_healthy }
-      clickhouse:        { condition: service_healthy }
-      minio:             { condition: service_healthy }
-      minio-init:        { condition: service_completed_successfully }
-    ports:
-      - "3001:3000"
-    environment:
-      NODE_OPTIONS: "--max-old-space-size=512"
-      DATABASE_URL: postgresql://langfuse:langfuse123@langfuse-postgres:5432/langfuse
-      NEXTAUTH_URL: http://localhost:3001
-      NEXTAUTH_SECRET: "dawn-langfuse-nextauth-secret-change-me"
-      SALT: "dawn-langfuse-salt-change-me"
-      ENCRYPTION_KEY: "0000000000000000000000000000000000000000000000000000000000000000"
-      TELEMETRY_ENABLED: "false"
-      CLICKHOUSE_URL: http://clickhouse:8123
-      CLICKHOUSE_MIGRATION_URL: clickhouse://clickhouse:9000
-      CLICKHOUSE_USER: clickhouse
-      CLICKHOUSE_PASSWORD: clickhouse123
-      CLICKHOUSE_CLUSTER_ENABLED: "false"
-      LANGFUSE_S3_EVENT_UPLOAD_BUCKET: langfuse
-      LANGFUSE_S3_EVENT_UPLOAD_REGION: auto
-      LANGFUSE_S3_EVENT_UPLOAD_ACCESS_KEY_ID: minio
-      LANGFUSE_S3_EVENT_UPLOAD_SECRET_ACCESS_KEY: minio12345
-      LANGFUSE_S3_EVENT_UPLOAD_ENDPOINT: http://minio:9000
-      LANGFUSE_S3_EVENT_UPLOAD_FORCE_PATH_STYLE: "true"
-      LANGFUSE_S3_EVENT_UPLOAD_PREFIX: "events/"
-      REDIS_HOST: langfuse-redis
-      REDIS_PORT: 6379
-      REDIS_AUTH: langfuse123
-      LANGFUSE_INIT_ORG_ID: ${LANGFUSE_INIT_ORG_ID:-dawn-ai}
-      LANGFUSE_INIT_ORG_NAME: ${LANGFUSE_INIT_ORG_NAME:-Dawn AI}
-      LANGFUSE_INIT_PROJECT_ID: ${LANGFUSE_INIT_PROJECT_ID:-dawn-ai}
-      LANGFUSE_INIT_PROJECT_NAME: ${LANGFUSE_INIT_PROJECT_NAME:-dawn-ai}
-      LANGFUSE_INIT_PROJECT_PUBLIC_KEY: ${LANGFUSE_INIT_PROJECT_PUBLIC_KEY:-pk-lf-dawn-dev}
-      LANGFUSE_INIT_PROJECT_SECRET_KEY: ${LANGFUSE_INIT_PROJECT_SECRET_KEY:-sk-lf-dawn-dev}
-      LANGFUSE_INIT_USER_EMAIL: ${LANGFUSE_INIT_USER_EMAIL:-admin@dawn.local}
-      LANGFUSE_INIT_USER_PASSWORD: ${LANGFUSE_INIT_USER_PASSWORD:-dawn-admin-123}
-      LANGFUSE_INIT_USER_NAME: ${LANGFUSE_INIT_USER_NAME:-Dawn Admin}
-      # Allow LLM connections to host-machine services (e.g. oMLX via host.docker.internal)
-      # Ref: https://github.com/langfuse/langfuse/pull/13073
-      LANGFUSE_LLM_CONNECTION_WHITELISTED_HOST: host.docker.internal
-    healthcheck:
-      test: ["CMD", "wget", "-q", "--spider", "http://localhost:3000/api/public/health"]
-      interval: 15s
-      timeout: 5s
-      retries: 20
-      start_period: 60s
-    networks:
-      - dawn-network
-
 volumes:
   huggingface_cache:
   postgres_data:
   redis_data:
-  grafana_data:
-  langfuse_postgres_data:
-  clickhouse_data:
-  langfuse_redis_data:
-  minio_data:
 
 networks:
   dawn-network:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,6 +35,9 @@ services:
       - LANGFUSE_OTLP_ENDPOINT=${LANGFUSE_OTLP_ENDPOINT:-http://langfuse-web:3000/api/public/otel/v1/traces}
       - LANGFUSE_AUTH_BASE64=${LANGFUSE_AUTH_BASE64}
       - LANGFUSE_ENVIRONMENT=${LANGFUSE_ENVIRONMENT:-dev}
+      # Set to false (or to `LANGFUSE_TRACING_ENABLED=false` in .env) when
+      # running without the `observe` profile, to silence OTLP exporter warns.
+      - MANAGEMENT_TRACING_ENABLED=${LANGFUSE_TRACING_ENABLED:-true}
     depends_on:
       postgres:
         condition: service_healthy
@@ -107,10 +110,16 @@ services:
     networks:
       - dawn-network
 
-  # ───────── Langfuse v3 (LLM observability) ─────────
+  # ───────── Langfuse v3 (LLM observability, opt-in profile) ─────────
+  # All services below are gated by `profiles: ["observe"]`. Daily dev:
+  #   docker compose up -d                    # business only, no Langfuse
+  # When you want traces:
+  #   docker compose --profile observe up -d  # adds the full Langfuse stack
   langfuse-postgres:
     image: postgres:16-alpine
+    profiles: ["observe"]
     restart: unless-stopped
+    mem_limit: 192m
     environment:
       POSTGRES_USER: langfuse
       POSTGRES_PASSWORD: langfuse123
@@ -129,8 +138,10 @@ services:
 
   langfuse-redis:
     image: redis:7-alpine
+    profiles: ["observe"]
     restart: unless-stopped
-    command: redis-server --appendonly yes --requirepass langfuse123
+    mem_limit: 64m
+    command: redis-server --appendonly yes --requirepass langfuse123 --maxmemory 32mb --maxmemory-policy allkeys-lru
     volumes:
       - langfuse_redis_data:/data
     healthcheck:
@@ -143,13 +154,16 @@ services:
 
   clickhouse:
     image: clickhouse/clickhouse-server:24.3
+    profiles: ["observe"]
     restart: unless-stopped
+    mem_limit: 768m
     environment:
       CLICKHOUSE_USER: clickhouse
       CLICKHOUSE_PASSWORD: clickhouse123
       CLICKHOUSE_DB: default
     volumes:
       - clickhouse_data:/var/lib/clickhouse
+      - ./clickhouse/config.d:/etc/clickhouse-server/config.d:ro
     ulimits:
       nofile:
         soft: 262144
@@ -164,7 +178,9 @@ services:
 
   minio:
     image: minio/minio:latest
+    profiles: ["observe"]
     restart: unless-stopped
+    mem_limit: 256m
     command: server --address ":9000" --console-address ":9001" /data
     environment:
       MINIO_ROOT_USER: minio
@@ -183,6 +199,7 @@ services:
   # so the `langfuse` bucket must exist before ingestion succeeds.
   minio-init:
     image: minio/mc:latest
+    profiles: ["observe"]
     depends_on:
       minio: { condition: service_healthy }
     restart: "no"
@@ -197,7 +214,9 @@ services:
 
   langfuse-worker:
     image: langfuse/langfuse-worker:3
+    profiles: ["observe"]
     restart: unless-stopped
+    mem_limit: 384m
     depends_on:
       langfuse-postgres: { condition: service_healthy }
       langfuse-redis:    { condition: service_healthy }
@@ -205,6 +224,7 @@ services:
       minio:             { condition: service_healthy }
       minio-init:        { condition: service_completed_successfully }
     environment:
+      NODE_OPTIONS: "--max-old-space-size=320"
       DATABASE_URL: postgresql://langfuse:langfuse123@langfuse-postgres:5432/langfuse
       SALT: "dawn-langfuse-salt-change-me"
       ENCRYPTION_KEY: "0000000000000000000000000000000000000000000000000000000000000000"
@@ -229,7 +249,9 @@ services:
 
   langfuse-web:
     image: langfuse/langfuse:3
+    profiles: ["observe"]
     restart: unless-stopped
+    mem_limit: 640m
     depends_on:
       langfuse-postgres: { condition: service_healthy }
       langfuse-redis:    { condition: service_healthy }
@@ -239,6 +261,7 @@ services:
     ports:
       - "3001:3000"
     environment:
+      NODE_OPTIONS: "--max-old-space-size=512"
       DATABASE_URL: postgresql://langfuse:langfuse123@langfuse-postgres:5432/langfuse
       NEXTAUTH_URL: http://localhost:3001
       NEXTAUTH_SECRET: "dawn-langfuse-nextauth-secret-change-me"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -104,11 +104,168 @@ services:
     networks:
       - dawn-network
 
+  # ───────── Langfuse v3 (LLM observability) ─────────
+  langfuse-postgres:
+    image: postgres:16-alpine
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: langfuse
+      POSTGRES_PASSWORD: langfuse123
+      POSTGRES_DB: langfuse
+    volumes:
+      - langfuse_postgres_data:/var/lib/postgresql/data
+    ports:
+      - "5433:5432"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U langfuse -d langfuse"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+    networks:
+      - dawn-network
+
+  langfuse-redis:
+    image: redis:7-alpine
+    restart: unless-stopped
+    command: redis-server --appendonly yes --requirepass langfuse123
+    volumes:
+      - langfuse_redis_data:/data
+    healthcheck:
+      test: ["CMD", "redis-cli", "-a", "langfuse123", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+    networks:
+      - dawn-network
+
+  clickhouse:
+    image: clickhouse/clickhouse-server:24.3
+    restart: unless-stopped
+    environment:
+      CLICKHOUSE_USER: clickhouse
+      CLICKHOUSE_PASSWORD: clickhouse123
+      CLICKHOUSE_DB: default
+    volumes:
+      - clickhouse_data:/var/lib/clickhouse
+    ulimits:
+      nofile:
+        soft: 262144
+        hard: 262144
+    healthcheck:
+      test: ["CMD-SHELL", "clickhouse-client --user clickhouse --password clickhouse123 --query 'SELECT 1' || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+    networks:
+      - dawn-network
+
+  minio:
+    image: minio/minio:latest
+    restart: unless-stopped
+    command: server --address ":9000" --console-address ":9001" /data
+    environment:
+      MINIO_ROOT_USER: minio
+      MINIO_ROOT_PASSWORD: minio12345
+    volumes:
+      - minio_data:/data
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+    networks:
+      - dawn-network
+
+  langfuse-worker:
+    image: langfuse/langfuse-worker:3
+    restart: unless-stopped
+    depends_on:
+      langfuse-postgres: { condition: service_healthy }
+      langfuse-redis:    { condition: service_healthy }
+      clickhouse:        { condition: service_healthy }
+      minio:             { condition: service_healthy }
+    environment:
+      DATABASE_URL: postgresql://langfuse:langfuse123@langfuse-postgres:5432/langfuse
+      SALT: "dawn-langfuse-salt-change-me"
+      ENCRYPTION_KEY: "0000000000000000000000000000000000000000000000000000000000000000"
+      TELEMETRY_ENABLED: "false"
+      CLICKHOUSE_URL: http://clickhouse:8123
+      CLICKHOUSE_MIGRATION_URL: clickhouse://clickhouse:9000
+      CLICKHOUSE_USER: clickhouse
+      CLICKHOUSE_PASSWORD: clickhouse123
+      CLICKHOUSE_CLUSTER_ENABLED: "false"
+      LANGFUSE_S3_EVENT_UPLOAD_BUCKET: langfuse
+      LANGFUSE_S3_EVENT_UPLOAD_REGION: auto
+      LANGFUSE_S3_EVENT_UPLOAD_ACCESS_KEY_ID: minio
+      LANGFUSE_S3_EVENT_UPLOAD_SECRET_ACCESS_KEY: minio12345
+      LANGFUSE_S3_EVENT_UPLOAD_ENDPOINT: http://minio:9000
+      LANGFUSE_S3_EVENT_UPLOAD_FORCE_PATH_STYLE: "true"
+      LANGFUSE_S3_EVENT_UPLOAD_PREFIX: "events/"
+      REDIS_HOST: langfuse-redis
+      REDIS_PORT: 6379
+      REDIS_AUTH: langfuse123
+    networks:
+      - dawn-network
+
+  langfuse-web:
+    image: langfuse/langfuse:3
+    restart: unless-stopped
+    depends_on:
+      langfuse-postgres: { condition: service_healthy }
+      langfuse-redis:    { condition: service_healthy }
+      clickhouse:        { condition: service_healthy }
+      minio:             { condition: service_healthy }
+    ports:
+      - "3001:3000"
+    environment:
+      DATABASE_URL: postgresql://langfuse:langfuse123@langfuse-postgres:5432/langfuse
+      NEXTAUTH_URL: http://localhost:3001
+      NEXTAUTH_SECRET: "dawn-langfuse-nextauth-secret-change-me"
+      SALT: "dawn-langfuse-salt-change-me"
+      ENCRYPTION_KEY: "0000000000000000000000000000000000000000000000000000000000000000"
+      TELEMETRY_ENABLED: "false"
+      CLICKHOUSE_URL: http://clickhouse:8123
+      CLICKHOUSE_MIGRATION_URL: clickhouse://clickhouse:9000
+      CLICKHOUSE_USER: clickhouse
+      CLICKHOUSE_PASSWORD: clickhouse123
+      CLICKHOUSE_CLUSTER_ENABLED: "false"
+      LANGFUSE_S3_EVENT_UPLOAD_BUCKET: langfuse
+      LANGFUSE_S3_EVENT_UPLOAD_REGION: auto
+      LANGFUSE_S3_EVENT_UPLOAD_ACCESS_KEY_ID: minio
+      LANGFUSE_S3_EVENT_UPLOAD_SECRET_ACCESS_KEY: minio12345
+      LANGFUSE_S3_EVENT_UPLOAD_ENDPOINT: http://minio:9000
+      LANGFUSE_S3_EVENT_UPLOAD_FORCE_PATH_STYLE: "true"
+      LANGFUSE_S3_EVENT_UPLOAD_PREFIX: "events/"
+      REDIS_HOST: langfuse-redis
+      REDIS_PORT: 6379
+      REDIS_AUTH: langfuse123
+      LANGFUSE_INIT_ORG_ID: ${LANGFUSE_INIT_ORG_ID:-dawn-ai}
+      LANGFUSE_INIT_ORG_NAME: ${LANGFUSE_INIT_ORG_NAME:-Dawn AI}
+      LANGFUSE_INIT_PROJECT_ID: ${LANGFUSE_INIT_PROJECT_ID:-dawn-ai}
+      LANGFUSE_INIT_PROJECT_NAME: ${LANGFUSE_INIT_PROJECT_NAME:-dawn-ai}
+      LANGFUSE_INIT_PROJECT_PUBLIC_KEY: ${LANGFUSE_INIT_PROJECT_PUBLIC_KEY:-pk-lf-dawn-dev}
+      LANGFUSE_INIT_PROJECT_SECRET_KEY: ${LANGFUSE_INIT_PROJECT_SECRET_KEY:-sk-lf-dawn-dev}
+      LANGFUSE_INIT_USER_EMAIL: ${LANGFUSE_INIT_USER_EMAIL:-admin@dawn.local}
+      LANGFUSE_INIT_USER_PASSWORD: ${LANGFUSE_INIT_USER_PASSWORD:-dawn-admin-123}
+      LANGFUSE_INIT_USER_NAME: ${LANGFUSE_INIT_USER_NAME:-Dawn Admin}
+    healthcheck:
+      test: ["CMD", "wget", "-q", "--spider", "http://localhost:3000/api/public/health"]
+      interval: 15s
+      timeout: 5s
+      retries: 20
+      start_period: 60s
+    networks:
+      - dawn-network
+
 volumes:
   huggingface_cache:
   postgres_data:
   redis_data:
   grafana_data:
+  langfuse_postgres_data:
+  clickhouse_data:
+  langfuse_redis_data:
+  minio_data:
 
 networks:
   dawn-network:

--- a/docs/superpowers/plans/2026-05-11-langfuse-integration.md
+++ b/docs/superpowers/plans/2026-05-11-langfuse-integration.md
@@ -1,47 +1,47 @@
-# Langfuse Integration Implementation Plan
+# Langfuse 集成实施计划
 
-> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+> **给 Agent 执行者：** 必须使用技能 superpowers:subagent-driven-development（推荐）或 superpowers:executing-plans 逐任务执行本计划。每个步骤使用复选框（`- [ ]`）语法跟踪进度。
 
-**Goal:** Self-host Langfuse v3 in `docker-compose.yml` and ship every Spring AI Observation span (chat, embedding, vector store, advisor, tool-calling) to Langfuse via OTLP/HTTP, correlated by the existing `AiInteractionContext.sessionId`.
+**目标：** 在 `docker-compose.yml` 中自托管 Langfuse v3，并将所有 Spring AI Observation Span（chat、embedding、vector store、advisor、tool-calling）通过 OTLP/HTTP 协议推送到 Langfuse，并与现有的 `AiInteractionContext.sessionId` 关联。
 
-**Architecture:** Pure protocol-level integration (Langfuse has no Java SDK). Spring AI's built-in Micrometer Observations → `micrometer-tracing-bridge-otel` → `opentelemetry-exporter-otlp` → Langfuse v3 OTLP ingestion endpoint. Existing Prometheus + Grafana metrics pipeline is **not** touched. App boot must **not** depend on the Langfuse stack.
+**架构：** 纯协议层集成（Langfuse 没有官方 Java SDK）。Spring AI 内置 Micrometer Observations → `micrometer-tracing-bridge-otel` → `opentelemetry-exporter-otlp` → Langfuse v3 OTLP 摄入端点。现有 Prometheus + Grafana 指标流水线**不受影响**。应用启动**不得**依赖 Langfuse 服务栈。
 
-**Tech Stack:** Spring Boot 3.2.5, Spring AI 1.1.4, Micrometer Tracing, OpenTelemetry SDK 1.x, Langfuse v3 (Web + Worker + ClickHouse + Postgres + Redis + MinIO), Docker Compose.
+**技术栈：** Spring Boot 3.2.5、Spring AI 1.1.4、Micrometer Tracing、OpenTelemetry SDK 1.x、Langfuse v3（Web + Worker + ClickHouse + Postgres + Redis + MinIO）、Docker Compose。
 
-**Spec:** `docs/superpowers/specs/2026-05-11-langfuse-integration-design.md`
+**设计规格文档：** `docs/superpowers/specs/2026-05-11-langfuse-integration-design.md`
 
-**Branch:** `feat/langfuse-integration` (already created, design spec already committed)
+**分支：** `feat/langfuse-integration`（已创建，设计规格文档已提交）
 
 ---
 
-## File Map (decomposition decisions)
+## 文件映射（拆分决策）
 
-| Path | Action | Responsibility |
+| 路径 | 操作 | 职责 |
 |---|---|---|
-| `docker-compose.yml` | Modify | Add 6 services + 4 volumes for Langfuse v3 stack |
-| `.env.example` | Modify | Add Langfuse bootstrap + OTLP env vars |
-| `pom.xml` | Modify | Add `micrometer-tracing-bridge-otel` + `opentelemetry-exporter-otlp` |
-| `src/main/resources/application.yml` | Modify | Add `management.tracing.*`, `management.otlp.tracing.*`, `spring.ai.{chat,tools}.observations.*`, `langfuse.environment` |
-| `src/main/java/com/dawn/ai/config/LangfuseObservationConfig.java` | Create | Single `@Configuration`: `ObservationFilter` (per-span `session.id`) + OTel resource customizer (process-wide `langfuse.environment`) |
-| `src/test/java/com/dawn/ai/config/LangfuseObservationConfigTest.java` | Create | Unit-test the filter contract: emits `session.id` iff context has one |
-| `scripts/langfuse-auth-header.sh` | Create | Helper: print `base64(public:secret)` for `LANGFUSE_AUTH_BASE64` |
-| `README.md` | Modify | Append "📊 Observability (Langfuse)" section |
+| `docker-compose.yml` | 修改 | 新增 6 个服务 + 4 个 Volume（Langfuse v3 服务栈） |
+| `.env.example` | 修改 | 新增 Langfuse 初始化引导 + OTLP 环境变量 |
+| `pom.xml` | 修改 | 新增 `micrometer-tracing-bridge-otel` + `opentelemetry-exporter-otlp` |
+| `src/main/resources/application.yml` | 修改 | 新增 `management.tracing.*`、`management.otlp.tracing.*`、`spring.ai.{chat,tools}.observations.*`、`langfuse.environment` |
+| `src/main/java/com/dawn/ai/config/LangfuseObservationConfig.java` | 新建 | 单一 `@Configuration`：`ObservationFilter`（每 Span 注入 `session.id`）+ OTel Resource 定制器（进程级 `langfuse.environment`） |
+| `src/test/java/com/dawn/ai/config/LangfuseObservationConfigTest.java` | 新建 | 单元测试 filter 契约：有 sessionId 时发射 `session.id`，无时不发射 |
+| `scripts/langfuse-auth-header.sh` | 新建 | 辅助脚本：输出 `base64(public:secret)` 用于 `LANGFUSE_AUTH_BASE64` |
+| `README.md` | 修改 | 追加"📊 可观测性（Langfuse）"章节 |
 
-**Why these boundaries:**
-- All wiring lives in **one** new `@Configuration` so future spec changes (add `user.id`, more attributes) touch one file.
-- Test file isolated to `config/` mirroring the production package.
-- Helper script keeps secret encoding out of operator's shell history.
+**边界划分原因：**
+- 所有接线逻辑集中在**一个**新的 `@Configuration` 类中，未来规格变更（如新增 `user.id` 等属性）只需修改一个文件。
+- 测试文件置于 `config/` 包下，与生产代码包结构镜像对应。
+- 辅助脚本将密钥编码操作从操作者的 shell 历史记录中隔离出去。
 
 ---
 
-## Task 1: Add Langfuse stack to docker-compose
+## 任务 1：将 Langfuse 服务栈加入 docker-compose
 
-**Files:**
-- Modify: `docker-compose.yml`
+**涉及文件：**
+- 修改：`docker-compose.yml`
 
-- [ ] **Step 1: Append Langfuse services to `services:` block**
+- [ ] **步骤 1：在 `services:` 块中追加 Langfuse 服务**
 
-Insert **before** the closing `volumes:` block in `docker-compose.yml`:
+在 `docker-compose.yml` 末尾的 `volumes:` 块**之前**插入：
 
 ```yaml
   # ───────── Langfuse v3 (LLM observability) ─────────
@@ -198,9 +198,9 @@ Insert **before** the closing `volumes:` block in `docker-compose.yml`:
       - dawn-network
 ```
 
-- [ ] **Step 2: Add the 4 new named volumes**
+- [ ] **步骤 2：新增 4 个命名 Volume**
 
-Modify the `volumes:` block at the bottom — add `langfuse_postgres_data`, `langfuse_redis_data`, `clickhouse_data`, `minio_data`:
+修改文件底部的 `volumes:` 块，追加 `langfuse_postgres_data`、`langfuse_redis_data`、`clickhouse_data`、`minio_data`：
 
 ```yaml
 volumes:
@@ -214,14 +214,14 @@ volumes:
   minio_data:
 ```
 
-- [ ] **Step 3: Verify YAML and bring up the stack**
+- [ ] **步骤 3：验证 YAML 并启动服务栈**
 
-Run:
+执行：
 ```bash
 docker compose config --quiet && echo "YAML OK"
 docker compose up -d langfuse-postgres langfuse-redis clickhouse minio
 ```
-Expected: `YAML OK`, then 4 containers running.
+预期：输出 `YAML OK`，4 个容器正常运行。
 
 ```bash
 docker compose up -d langfuse-worker langfuse-web
@@ -229,21 +229,21 @@ sleep 60
 docker compose ps langfuse-web
 curl -fsS http://localhost:3001/api/public/health && echo OK
 ```
-Expected: `langfuse-web` shows `(healthy)`, curl returns `OK`.
+预期：`langfuse-web` 状态显示 `(healthy)`，curl 返回 `OK`。
 
-- [ ] **Step 4: Smoke-test the OTLP endpoint exists**
+- [ ] **步骤 4：冒烟测试 OTLP 端点是否存在**
 
-Run:
+执行：
 ```bash
 curl -s -o /dev/null -w "%{http_code}\n" \
   -X POST http://localhost:3001/api/public/otel/v1/traces \
   -H "Content-Type: application/x-protobuf"
 ```
-Expected: `401` (rejects unauthenticated, but proves the route exists). NOT `404`.
+预期：返回 `401`（未认证被拒绝，但证明路由存在）。**不应**返回 `404`。
 
-If 404: Langfuse v3 OTLP not enabled — re-check image tag is `:3`, not `:2`.
+若返回 404：Langfuse v3 OTLP 未启用——请检查镜像标签是否为 `:3` 而非 `:2`。
 
-- [ ] **Step 5: Commit**
+- [ ] **步骤 5：提交**
 
 ```bash
 git add docker-compose.yml
@@ -256,15 +256,15 @@ to avoid Grafana on 3000. ClickHouse/Redis/MinIO are internal-only."
 
 ---
 
-## Task 2: Add Langfuse env vars and helper script
+## 任务 2：新增 Langfuse 环境变量与辅助脚本
 
-**Files:**
-- Modify: `.env.example`
-- Create: `scripts/langfuse-auth-header.sh`
+**涉及文件：**
+- 修改：`.env.example`
+- 新建：`scripts/langfuse-auth-header.sh`
 
-- [ ] **Step 1: Append Langfuse block to `.env.example`**
+- [ ] **步骤 1：在 `.env.example` 末尾追加 Langfuse 配置块**
 
-Append at the end of `.env.example`:
+在 `.env.example` 末尾追加：
 
 ```dotenv
 
@@ -290,9 +290,9 @@ LANGFUSE_AUTH_BASE64=cGstbGYtZGF3bi1kZXY6c2stbGYtZGF3bi1kZXY=
 LANGFUSE_ENVIRONMENT=dev
 ```
 
-- [ ] **Step 2: Create `scripts/langfuse-auth-header.sh`**
+- [ ] **步骤 2：新建 `scripts/langfuse-auth-header.sh`**
 
-Create file with mode 755:
+创建文件并设置权限为 755：
 
 ```bash
 #!/usr/bin/env bash
@@ -313,22 +313,22 @@ printf '%s:%s' \
   | base64
 ```
 
-Then:
+然后执行：
 ```bash
 chmod +x scripts/langfuse-auth-header.sh
 ```
 
-- [ ] **Step 3: Verify script output matches the value baked into `.env.example`**
+- [ ] **步骤 3：验证脚本输出与 `.env.example` 中预置值一致**
 
-Run:
+执行：
 ```bash
 LANGFUSE_INIT_PROJECT_PUBLIC_KEY=pk-lf-dawn-dev \
 LANGFUSE_INIT_PROJECT_SECRET_KEY=sk-lf-dawn-dev \
   scripts/langfuse-auth-header.sh
 ```
-Expected: `cGstbGYtZGF3bi1kZXY6c2stbGYtZGF3bi1kZXY=` (matches `.env.example`).
+预期输出：`cGstbGYtZGF3bi1kZXY6c2stbGYtZGF3bi1kZXY=`（与 `.env.example` 中的值一致）。
 
-- [ ] **Step 4: Commit**
+- [ ] **步骤 4：提交**
 
 ```bash
 git add .env.example scripts/langfuse-auth-header.sh
@@ -337,14 +337,14 @@ git commit -m "feat(langfuse): add env vars and auth-header helper script"
 
 ---
 
-## Task 3: Add Maven dependencies
+## 任务 3：新增 Maven 依赖
 
-**Files:**
-- Modify: `pom.xml`
+**涉及文件：**
+- 修改：`pom.xml`
 
-- [ ] **Step 1: Add the two dependencies**
+- [ ] **步骤 1：新增两个依赖项**
 
-Locate the `<dependencies>` block in `pom.xml`. Add right after the existing `micrometer-registry-prometheus` dependency:
+在 `pom.xml` 的 `<dependencies>` 块中，紧接 `micrometer-registry-prometheus` 依赖项之后插入：
 
 ```xml
         <!-- Micrometer Tracing → OpenTelemetry bridge -->
@@ -360,18 +360,18 @@ Locate the `<dependencies>` block in `pom.xml`. Add right after the existing `mi
         </dependency>
 ```
 
-(Versions managed by `spring-boot-starter-parent` 3.2.5 — no explicit `<version>` needed.)
+（版本由 `spring-boot-starter-parent` 3.2.5 统一管理，无需填写 `<version>`。）
 
-- [ ] **Step 2: Verify the build resolves**
+- [ ] **步骤 2：验证构建依赖解析成功**
 
-Run:
+执行：
 ```bash
 mvn -q -DskipTests dependency:resolve | tail -20
 mvn -q -DskipTests compile
 ```
-Expected: BUILD SUCCESS, no "could not resolve" errors.
+预期：BUILD SUCCESS，无 "could not resolve" 错误。
 
-- [ ] **Step 3: Commit**
+- [ ] **步骤 3：提交**
 
 ```bash
 git add pom.xml
@@ -380,14 +380,14 @@ git commit -m "feat(langfuse): add micrometer-tracing-bridge-otel + opentelemetr
 
 ---
 
-## Task 4: Add tracing/OTLP/observation config to application.yml
+## 任务 4：在 application.yml 中添加 tracing/OTLP/observation 配置
 
-**Files:**
-- Modify: `src/main/resources/application.yml`
+**涉及文件：**
+- 修改：`src/main/resources/application.yml`
 
-- [ ] **Step 1: Extend `management:` block with tracing + otlp**
+- [ ] **步骤 1：在 `management:` 块中补充 tracing + otlp 配置**
 
-Replace the current `management:` block (lines starting at 62) with:
+将当前 `management:` 块（约从第 62 行开始）替换为：
 
 ```yaml
 # Actuator & Prometheus Metrics + OTLP tracing → Langfuse
@@ -414,9 +414,9 @@ management:
         Authorization: Basic ${LANGFUSE_AUTH_BASE64:}
 ```
 
-- [ ] **Step 2: Enable Spring AI prompt/completion/tool content logging**
+- [ ] **步骤 2：开启 Spring AI prompt/completion/tool 内容日志**
 
-Add the following under the existing `spring.ai:` block (insert after the `vectorstore:` section, still within `spring.ai:`):
+在现有 `spring.ai:` 块下（`vectorstore:` 段之后，仍在 `spring.ai:` 内）追加：
 
 ```yaml
     chat:
@@ -428,9 +428,9 @@ Add the following under the existing `spring.ai:` block (insert after the `vecto
         include-content: true
 ```
 
-- [ ] **Step 3: Add `langfuse:` top-level block (read by the resource customizer)**
+- [ ] **步骤 3：在文件末尾添加顶级 `langfuse:` 配置块（供 Resource 定制器读取）**
 
-Append at the end of the file:
+在文件末尾追加：
 
 ```yaml
 # Langfuse environment label, attached as OTel resource attribute
@@ -438,9 +438,9 @@ langfuse:
   environment: ${LANGFUSE_ENVIRONMENT:dev}
 ```
 
-- [ ] **Step 4: Verify YAML parses**
+- [ ] **步骤 4：验证 YAML 解析正确**
 
-Run:
+执行：
 ```bash
 mvn -q -DskipTests spring-boot:run -Dspring-boot.run.arguments="--spring.config.activate.on-profile=lint --spring.main.web-application-type=none --spring.main.lazy-initialization=true" &
 APP_PID=$!
@@ -448,31 +448,31 @@ sleep 12
 kill $APP_PID 2>/dev/null || true
 ```
 
-Easier alt — just compile and let Spring's strict YAML parser catch it on next test run. Skip this step if `mvn compile` already passed.
+更简便的替代方案——直接编译，让 Spring 严格 YAML 解析器在下一次测试时捕获错误。若 `mvn compile` 已通过，可跳过此步骤。
 
-- [ ] **Step 5: Commit**
+- [ ] **步骤 5：提交**
 
 ```bash
 git add src/main/resources/application.yml
 git commit -m "feat(langfuse): wire OTLP tracing + Spring AI observation content logging
 
-- management.tracing.sampling.probability=1.0 (dev)
-- management.otlp.tracing endpoint/headers/gzip
+- management.tracing.sampling.probability=1.0（dev 开发环境）
+- management.otlp.tracing 端点/认证头/gzip 压缩
 - spring.ai.chat.observations.log-prompt/completion=true
 - spring.ai.tools.observations.include-content=true
-- langfuse.environment label"
+- langfuse.environment 环境标签"
 ```
 
 ---
 
-## Task 5: Write failing test for `LangfuseObservationConfig` filter
+## 任务 5：编写红测（失败优先）——`LangfuseObservationConfig` filter 测试
 
-**Files:**
-- Create: `src/test/java/com/dawn/ai/config/LangfuseObservationConfigTest.java`
+**涉及文件：**
+- 新建：`src/test/java/com/dawn/ai/config/LangfuseObservationConfigTest.java`
 
-- [ ] **Step 1: Write the test**
+- [ ] **步骤 1：编写测试类**
 
-Create the file:
+创建文件：
 
 ```java
 package com.dawn.ai.config;
@@ -538,26 +538,26 @@ class LangfuseObservationConfigTest {
 }
 ```
 
-> Note: `AiInteractionContext.setSessionId(blank)` already calls `remove()` per its existing implementation, so the third test asserts the *resulting* behavior (no `session.id` emitted) regardless of which layer enforces it.
+> 注意：`AiInteractionContext.setSessionId(blank)` 在现有实现中已调用 `remove()`，因此第三个测试断言的是**最终行为**（不发射 `session.id`），无论由哪层来执行这个逻辑。
 
-- [ ] **Step 2: Run test — must FAIL**
+- [ ] **步骤 2：运行测试——必须失败**
 
-Run:
+执行：
 ```bash
 mvn -q -Dtest=LangfuseObservationConfigTest test
 ```
-Expected: compilation FAIL — `LangfuseObservationConfig` does not exist.
+预期：编译失败——`LangfuseObservationConfig` 尚不存在。
 
 ---
 
-## Task 6: Implement `LangfuseObservationConfig`
+## 任务 6：实现 `LangfuseObservationConfig`
 
-**Files:**
-- Create: `src/main/java/com/dawn/ai/config/LangfuseObservationConfig.java`
+**涉及文件：**
+- 新建：`src/main/java/com/dawn/ai/config/LangfuseObservationConfig.java`
 
-- [ ] **Step 1: Implement the class**
+- [ ] **步骤 1：实现该类**
 
-Create:
+创建文件：
 
 ```java
 package com.dawn.ai.config;
@@ -612,45 +612,42 @@ public class LangfuseObservationConfig {
 }
 ```
 
-- [ ] **Step 2: Run the unit test — must PASS**
+- [ ] **步骤 2：运行单元测试——必须通过**
 
-Run:
+执行：
 ```bash
 mvn -q -Dtest=LangfuseObservationConfigTest test
 ```
-Expected: 3 tests, BUILD SUCCESS.
+预期：3 个测试，BUILD SUCCESS。
 
-- [ ] **Step 3: Run full test suite to ensure no regression**
+- [ ] **步骤 3：运行完整测试套件，确认无回归**
 
-Run:
+执行：
 ```bash
 mvn -q test
 ```
-Expected: BUILD SUCCESS.
+预期：BUILD SUCCESS。
 
-- [ ] **Step 4: Commit**
+- [ ] **步骤 4：提交**
 
 ```bash
 git add src/main/java/com/dawn/ai/config/LangfuseObservationConfig.java \
         src/test/java/com/dawn/ai/config/LangfuseObservationConfigTest.java
 git commit -m "feat(langfuse): inject session.id ObservationFilter + langfuse.environment OTel resource
 
-Per-span session.id is read from the existing AiInteractionContext
-(already propagated across Reactor / boundedElastic by
-AiInteractionContextAccessor). langfuse.environment is set as a
-process-wide OTel resource attribute via SDK customizer."
+每个 Span 的 session.id 从现有的 AiInteractionContext 读取
+（已由 AiInteractionContextAccessor 跨 Reactor / boundedElastic 传播）。
+langfuse.environment 通过 SDK 定制器设置为进程级 OTel 资源属性。"
 ```
 
 ---
 
-## Task 7: Wire app container env so it reaches Langfuse over the dawn-network
+## 任务 7：为 app 容器注入环境变量，使其可访问 dawn-network 上的 Langfuse
 
-**Files:**
-- Modify: `docker-compose.yml`
+**涉及文件：**
+- 修改：`docker-compose.yml`
 
-- [ ] **Step 1: Add 3 env vars to the `app:` service environment**
-
-In the `app:` service `environment:` block, append:
+- [ ] **步骤 1：在 `app:` 服务的 `environment:` 块中追加 3 个环境变量**
 
 ```yaml
       - LANGFUSE_OTLP_ENDPOINT=${LANGFUSE_OTLP_ENDPOINT:-http://langfuse-web:3000/api/public/otel/v1/traces}
@@ -658,19 +655,17 @@ In the `app:` service `environment:` block, append:
       - LANGFUSE_ENVIRONMENT=${LANGFUSE_ENVIRONMENT:-dev}
 ```
 
-> NOTE: do **NOT** add Langfuse services to `app.depends_on`. Per spec §9, the
-> business app must boot independently of the observability stack — early traces
-> are dropped silently if langfuse-web is not yet ready.
+> 注意：**不得**将 Langfuse 服务加入 `app.depends_on`。根据规格文档第 9 节，业务应用必须独立启动，与可观测性服务栈无关——若 langfuse-web 尚未就绪，早期 Span 将被 OTel 导出器静默丢弃。
 
-- [ ] **Step 2: Validate compose**
+- [ ] **步骤 2：验证 Compose 配置**
 
-Run:
+执行：
 ```bash
 docker compose config --quiet && echo OK
 ```
-Expected: `OK`.
+预期：输出 `OK`。
 
-- [ ] **Step 3: Commit**
+- [ ] **步骤 3：提交**
 
 ```bash
 git add docker-compose.yml
@@ -679,51 +674,51 @@ git commit -m "feat(langfuse): pass OTLP endpoint + auth + env to app container"
 
 ---
 
-## Task 8: End-to-end verification
+## 任务 8：端到端验证
 
-**Files:** none (manual verification)
+**涉及文件：** 无（手动验证）
 
-- [ ] **Step 1: Bring up the full stack**
+- [ ] **步骤 1：启动完整服务栈**
 
-Run:
+执行：
 ```bash
 docker compose down
 docker compose up -d
 sleep 75
 docker compose ps
 ```
-Expected: every container shows `(healthy)` or `Up`. `langfuse-web` is `(healthy)`.
+预期：所有容器显示 `(healthy)` 或 `Up`，`langfuse-web` 状态为 `(healthy)`。
 
-- [ ] **Step 2: Sanity-check Langfuse UI**
+- [ ] **步骤 2：验证 Langfuse UI 可访问**
 
 ```bash
 open http://localhost:3001    # macOS
 ```
-Log in with `admin@dawn.local` / `dawn-admin-123`. Project `dawn-ai` should be pre-created.
+使用 `admin@dawn.local` / `dawn-admin-123` 登录，项目 `dawn-ai` 应已自动创建。
 
-- [ ] **Step 3: Trigger one chat round trip**
+- [ ] **步骤 3：触发一次完整的 Chat 请求**
 
-Run:
+执行：
 ```bash
 curl -s -X POST http://localhost:8080/api/v1/chat \
   -H 'Content-Type: application/json' \
   -d '{"message":"What is 2+2?","sessionId":"smoke-001"}' | jq .
 ```
-Expected: HTTP 200, JSON body with an answer.
+预期：HTTP 200，JSON 响应体包含答案。
 
-- [ ] **Step 4: Verify trace appears in Langfuse**
+- [ ] **步骤 4：在 Langfuse 中验证 Trace 出现**
 
-Wait ~5 seconds. In Langfuse UI:
+等待约 5 秒后，在 Langfuse UI 中：
 
-1. **Tracing** → see a new trace within 5–10 s.
-2. Open the trace → root span has model name, latency, token counts, **prompt + completion text visible**.
-3. Child spans visible for advisor / vector-store query / embedding (depending on chat path).
-4. Trace attribute panel shows `session.id = smoke-001` and `langfuse.environment = dev`.
-5. **Sessions** view (left nav) → session `smoke-001` is listed and groups the trace.
+1. **Tracing** 页面 → 5–10 秒内出现新 Trace。
+2. 打开该 Trace → 根 Span 包含模型名称、延迟、Token 用量，**prompt + completion 文本可见**。
+3. 子 Span 可见（advisor / vector-store query / embedding，取决于对话路径）。
+4. Trace 属性面板显示 `session.id = smoke-001` 和 `langfuse.environment = dev`。
+5. **Sessions** 视图（左侧导航）→ 会话 `smoke-001` 已列出并聚合该 Trace。
 
-- [ ] **Step 5: Verify resilience — Langfuse down does NOT break the app**
+- [ ] **步骤 5：验证容灾——Langfuse 宕机不影响业务请求**
 
-Run:
+执行：
 ```bash
 docker compose stop langfuse-web langfuse-worker
 sleep 3
@@ -732,76 +727,68 @@ curl -s -X POST http://localhost:8080/api/v1/chat \
   -d '{"message":"ping","sessionId":"smoke-002"}' -w "\nHTTP %{http_code}\n"
 docker compose start langfuse-web langfuse-worker
 ```
-Expected: HTTP 200 (chat succeeds even with Langfuse down).
+预期：HTTP 200（Langfuse 宕机时 Chat 请求仍然成功）。
 
-- [ ] **Step 6: Verify Prometheus pipeline still healthy (no regression)**
+- [ ] **步骤 6：验证 Prometheus 指标流水线无回归**
 
-Run:
+执行：
 ```bash
 curl -s http://localhost:8080/actuator/prometheus | head -20
 curl -s http://localhost:9090/-/healthy
 ```
-Expected: prometheus exposition format text; `Prometheus Server is Healthy.`.
+预期：输出 Prometheus 文本格式数据；`Prometheus Server is Healthy.`。
 
 ---
 
-## Task 9: Update README
+## 任务 9：更新 README
 
-**Files:**
-- Modify: `README.md`
+**涉及文件：**
+- 修改：`README.md`
 
-- [ ] **Step 1: Append observability section**
+- [ ] **步骤 1：在 README.md 末尾追加可观测性章节**
 
-Append at the end of `README.md`:
+在 `README.md` 末尾追加：
 
 ```markdown
 
-## 📊 Observability with Langfuse
+## 📊 可观测性（Langfuse）
 
-`docker compose up` brings up a self-hosted **Langfuse v3** stack alongside
-the app. Every Spring AI call (chat, embedding, vector-store, tool-call)
-is exported via OTLP to Langfuse — full prompt, completion, and tool I/O
-included.
+`docker compose up` 会在应用旁启动自托管的 **Langfuse v3** 服务栈。所有 Spring AI 调用（chat、embedding、vector-store、tool-call）均通过 OTLP 导出到 Langfuse，包含完整的 prompt、completion 与 tool I/O。
 
-### First run
+### 首次启动
 
 ```bash
 cp .env.example .env
-# (Optional) regenerate the auth header if you change keys:
-scripts/langfuse-auth-header.sh    # paste output into LANGFUSE_AUTH_BASE64
+# （可选）修改密鑰后重新生成认证头：
+scripts/langfuse-auth-header.sh    # 将输出粘贴到 LANGFUSE_AUTH_BASE64
 
 docker compose up -d
 ```
 
-Visit **http://localhost:3001** and log in:
+访问 **http://localhost:3001** 并登录：
 
-| Field | Value (defaults from `.env.example`) |
+| 字段 | 默认值（来自 `.env.example`） |
 |---|---|
-| Email | `admin@dawn.local` |
-| Password | `dawn-admin-123` |
+| 邮筱 | `admin@dawn.local` |
+| 密码 | `dawn-admin-123` |
 
-The `dawn-ai` project is auto-created. New chats appear under **Tracing**
-within seconds; the **Sessions** tab groups traces by the `sessionId` you
-pass in the chat request body.
+`dawn-ai` 项目已自动创建。新的对话几秒内出现在 **Tracing** 页面；**Sessions** 页面按 Chat 请求中传入的 `sessionId` 进行聚合。
 
-### What goes where
+### 数据分层
 
-| Stack | Purpose | UI |
+| 服务栈 | 用途 | UI 地址 |
 |---|---|---|
-| **Prometheus + Grafana** (existing) | Aggregate metrics, RED, SLOs | http://localhost:3000 |
-| **Langfuse** (new) | Per-request traces, prompts, tool I/O | http://localhost:3001 |
+| **Prometheus + Grafana**（现有） | 职指标汇总、RED 指标、SLO | http://localhost:3000 |
+| **Langfuse**（新增） | 单请求 Trace、Prompt、Tool I/O | http://localhost:3001 |
 
-The two are independent — Langfuse downtime never affects the app.
+两者相互独立——Langfuse 宕机不影响业务应用。
 
-### Rotating keys / production
+### 密鑰更换 / 生产环境
 
-Change `LANGFUSE_INIT_PROJECT_PUBLIC_KEY` and `_SECRET_KEY` in `.env`,
-re-run `scripts/langfuse-auth-header.sh`, paste the new value into
-`LANGFUSE_AUTH_BASE64`, then `docker compose up -d --force-recreate
-langfuse-web app`.
+在 `.env` 中修改 `LANGFUSE_INIT_PROJECT_PUBLIC_KEY` 和 `_SECRET_KEY`，重新执行 `scripts/langfuse-auth-header.sh`，将新值填入 `LANGFUSE_AUTH_BASE64`，然后执行 `docker compose up -d --force-recreate langfuse-web app`。
 ```
 
-- [ ] **Step 2: Commit**
+- [ ] **步骤 2：提交**
 
 ```bash
 git add README.md
@@ -810,36 +797,36 @@ git commit -m "docs(langfuse): document observability stack, first-run, and key 
 
 ---
 
-## Self-Review
+## 自审（Self-Review）
 
-**Spec coverage check:**
+**规格覆盖检查：**
 
-| Spec section | Implementing task |
+| 规格章节 | 对应实施任务 |
 |---|---|
-| §4 Architecture diagram | Tasks 1, 3, 4, 6 |
-| §5 Component inventory & ports | Task 1 |
-| §6.1 New env vars | Task 2 |
-| §6.2 application.yml additions | Task 4 |
-| §6.3 Maven dependencies | Task 3 |
-| §7.1 LangfuseObservationConfig | Tasks 5, 6 |
-| §7.2 No edits to existing classes | Tasks 5–6 honor this (only new files) |
-| §8 Acceptance verification | Task 8 |
-| §9 Failure modes (no depends_on) | Task 7 step 1 NOTE; Task 8 step 5 |
-| §10 Documentation (README, .env.example, helper script) | Tasks 2, 9 |
+| §4 架构图 | 任务 1、3、4、6 |
+| §5 组件清单与端口分配 | 任务 1 |
+| §6.1 新增环境变量 | 任务 2 |
+| §6.2 application.yml 补充 | 任务 4 |
+| §6.3 Maven 依赖 | 任务 3 |
+| §7.1 LangfuseObservationConfig | 任务 5、6 |
+| §7.2 不修改现有类 | 任务 5–6 只新建文件，符合要求 |
+| §8 验收核查 | 任务 8 |
+| §9 故障模式（no depends_on） | 任务 7 步骤 1 注意事项；任务 8 步骤 5 |
+| §10 文档（README、.env.example、辅助脚本） | 任务 2、9 |
 
-All spec items mapped — no gaps.
+所有规格条目均已映射，无遗漏。✔
 
-**Placeholder scan:** No "TBD", no "implement later", every code block contains the actual code. ✔
+**占位符扫描：** 无 "TBD"，无 "implement later"，每个代码块均为可执行的完整代码。✔
 
-**Type consistency:** `langfuseSessionFilter()` and `langfuseResourceCustomizer()` bean names match between Tasks 5 (test) and 6 (impl). `LANGFUSE_AUTH_BASE64`, `LANGFUSE_OTLP_ENDPOINT`, `LANGFUSE_ENVIRONMENT` env names consistent across Tasks 1, 2, 4, 7. ✔
+**命名一致性：** `langfuseSessionFilter()` 和 `langfuseResourceCustomizer()` Bean 名称在任务 5（测试）和任务 6（实现）之间保持一致。`LANGFUSE_AUTH_BASE64`、`LANGFUSE_OTLP_ENDPOINT`、`LANGFUSE_ENVIRONMENT` 环境变量名称在任务 1、2、4、7 中保持一致。✔
 
 ---
 
-## Execution Handoff
+## 执行交接
 
-Plan complete and saved to `docs/superpowers/plans/2026-05-11-langfuse-integration.md`. Two execution options:
+计划已完成并保存至 `docs/superpowers/plans/2026-05-11-langfuse-integration.md`。提供两种执行方式：
 
-1. **Subagent-Driven (recommended)** — I dispatch a fresh subagent per task, review between tasks, fast iteration.
-2. **Inline Execution** — Execute tasks in this session using executing-plans, batch execution with checkpoints.
+1. **子 Agent 驱动（推荐）** — 每个任务分派独立子 Agent 执行，任务间可人工审查，迭代速度快。
+2. **内联执行** — 在当前会话中使用 executing-plans 技能批量执行，按检查点推进。
 
-Which approach?
+请选择执行方式？

--- a/docs/superpowers/plans/2026-05-11-langfuse-integration.md
+++ b/docs/superpowers/plans/2026-05-11-langfuse-integration.md
@@ -1,0 +1,845 @@
+# Langfuse Integration Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Self-host Langfuse v3 in `docker-compose.yml` and ship every Spring AI Observation span (chat, embedding, vector store, advisor, tool-calling) to Langfuse via OTLP/HTTP, correlated by the existing `AiInteractionContext.sessionId`.
+
+**Architecture:** Pure protocol-level integration (Langfuse has no Java SDK). Spring AI's built-in Micrometer Observations → `micrometer-tracing-bridge-otel` → `opentelemetry-exporter-otlp` → Langfuse v3 OTLP ingestion endpoint. Existing Prometheus + Grafana metrics pipeline is **not** touched. App boot must **not** depend on the Langfuse stack.
+
+**Tech Stack:** Spring Boot 3.2.5, Spring AI 1.1.4, Micrometer Tracing, OpenTelemetry SDK 1.x, Langfuse v3 (Web + Worker + ClickHouse + Postgres + Redis + MinIO), Docker Compose.
+
+**Spec:** `docs/superpowers/specs/2026-05-11-langfuse-integration-design.md`
+
+**Branch:** `feat/langfuse-integration` (already created, design spec already committed)
+
+---
+
+## File Map (decomposition decisions)
+
+| Path | Action | Responsibility |
+|---|---|---|
+| `docker-compose.yml` | Modify | Add 6 services + 4 volumes for Langfuse v3 stack |
+| `.env.example` | Modify | Add Langfuse bootstrap + OTLP env vars |
+| `pom.xml` | Modify | Add `micrometer-tracing-bridge-otel` + `opentelemetry-exporter-otlp` |
+| `src/main/resources/application.yml` | Modify | Add `management.tracing.*`, `management.otlp.tracing.*`, `spring.ai.{chat,tools}.observations.*`, `langfuse.environment` |
+| `src/main/java/com/dawn/ai/config/LangfuseObservationConfig.java` | Create | Single `@Configuration`: `ObservationFilter` (per-span `session.id`) + OTel resource customizer (process-wide `langfuse.environment`) |
+| `src/test/java/com/dawn/ai/config/LangfuseObservationConfigTest.java` | Create | Unit-test the filter contract: emits `session.id` iff context has one |
+| `scripts/langfuse-auth-header.sh` | Create | Helper: print `base64(public:secret)` for `LANGFUSE_AUTH_BASE64` |
+| `README.md` | Modify | Append "📊 Observability (Langfuse)" section |
+
+**Why these boundaries:**
+- All wiring lives in **one** new `@Configuration` so future spec changes (add `user.id`, more attributes) touch one file.
+- Test file isolated to `config/` mirroring the production package.
+- Helper script keeps secret encoding out of operator's shell history.
+
+---
+
+## Task 1: Add Langfuse stack to docker-compose
+
+**Files:**
+- Modify: `docker-compose.yml`
+
+- [ ] **Step 1: Append Langfuse services to `services:` block**
+
+Insert **before** the closing `volumes:` block in `docker-compose.yml`:
+
+```yaml
+  # ───────── Langfuse v3 (LLM observability) ─────────
+  langfuse-postgres:
+    image: postgres:16-alpine
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: langfuse
+      POSTGRES_PASSWORD: langfuse123
+      POSTGRES_DB: langfuse
+    volumes:
+      - langfuse_postgres_data:/var/lib/postgresql/data
+    ports:
+      - "5433:5432"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U langfuse -d langfuse"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+    networks:
+      - dawn-network
+
+  langfuse-redis:
+    image: redis:7-alpine
+    restart: unless-stopped
+    command: redis-server --appendonly yes --requirepass langfuse123
+    volumes:
+      - langfuse_redis_data:/data
+    healthcheck:
+      test: ["CMD", "redis-cli", "-a", "langfuse123", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+    networks:
+      - dawn-network
+
+  clickhouse:
+    image: clickhouse/clickhouse-server:24.3
+    restart: unless-stopped
+    environment:
+      CLICKHOUSE_USER: clickhouse
+      CLICKHOUSE_PASSWORD: clickhouse123
+      CLICKHOUSE_DB: default
+    volumes:
+      - clickhouse_data:/var/lib/clickhouse
+    ulimits:
+      nofile:
+        soft: 262144
+        hard: 262144
+    healthcheck:
+      test: ["CMD-SHELL", "clickhouse-client --user clickhouse --password clickhouse123 --query 'SELECT 1' || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+    networks:
+      - dawn-network
+
+  minio:
+    image: minio/minio:latest
+    restart: unless-stopped
+    command: server --address ":9000" --console-address ":9001" /data
+    environment:
+      MINIO_ROOT_USER: minio
+      MINIO_ROOT_PASSWORD: minio12345
+    volumes:
+      - minio_data:/data
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+    networks:
+      - dawn-network
+
+  langfuse-worker:
+    image: langfuse/langfuse-worker:3
+    restart: unless-stopped
+    depends_on:
+      langfuse-postgres: { condition: service_healthy }
+      langfuse-redis:    { condition: service_healthy }
+      clickhouse:        { condition: service_healthy }
+      minio:             { condition: service_healthy }
+    environment:
+      DATABASE_URL: postgresql://langfuse:langfuse123@langfuse-postgres:5432/langfuse
+      SALT: "dawn-langfuse-salt-change-me"
+      ENCRYPTION_KEY: "0000000000000000000000000000000000000000000000000000000000000000"
+      TELEMETRY_ENABLED: "false"
+      CLICKHOUSE_URL: http://clickhouse:8123
+      CLICKHOUSE_MIGRATION_URL: clickhouse://clickhouse:9000
+      CLICKHOUSE_USER: clickhouse
+      CLICKHOUSE_PASSWORD: clickhouse123
+      CLICKHOUSE_CLUSTER_ENABLED: "false"
+      LANGFUSE_S3_EVENT_UPLOAD_BUCKET: langfuse
+      LANGFUSE_S3_EVENT_UPLOAD_REGION: auto
+      LANGFUSE_S3_EVENT_UPLOAD_ACCESS_KEY_ID: minio
+      LANGFUSE_S3_EVENT_UPLOAD_SECRET_ACCESS_KEY: minio12345
+      LANGFUSE_S3_EVENT_UPLOAD_ENDPOINT: http://minio:9000
+      LANGFUSE_S3_EVENT_UPLOAD_FORCE_PATH_STYLE: "true"
+      LANGFUSE_S3_EVENT_UPLOAD_PREFIX: "events/"
+      REDIS_HOST: langfuse-redis
+      REDIS_PORT: 6379
+      REDIS_AUTH: langfuse123
+    networks:
+      - dawn-network
+
+  langfuse-web:
+    image: langfuse/langfuse:3
+    restart: unless-stopped
+    depends_on:
+      langfuse-postgres: { condition: service_healthy }
+      langfuse-redis:    { condition: service_healthy }
+      clickhouse:        { condition: service_healthy }
+      minio:             { condition: service_healthy }
+    ports:
+      - "3001:3000"
+    environment:
+      DATABASE_URL: postgresql://langfuse:langfuse123@langfuse-postgres:5432/langfuse
+      NEXTAUTH_URL: http://localhost:3001
+      NEXTAUTH_SECRET: "dawn-langfuse-nextauth-secret-change-me"
+      SALT: "dawn-langfuse-salt-change-me"
+      ENCRYPTION_KEY: "0000000000000000000000000000000000000000000000000000000000000000"
+      TELEMETRY_ENABLED: "false"
+      CLICKHOUSE_URL: http://clickhouse:8123
+      CLICKHOUSE_MIGRATION_URL: clickhouse://clickhouse:9000
+      CLICKHOUSE_USER: clickhouse
+      CLICKHOUSE_PASSWORD: clickhouse123
+      CLICKHOUSE_CLUSTER_ENABLED: "false"
+      LANGFUSE_S3_EVENT_UPLOAD_BUCKET: langfuse
+      LANGFUSE_S3_EVENT_UPLOAD_REGION: auto
+      LANGFUSE_S3_EVENT_UPLOAD_ACCESS_KEY_ID: minio
+      LANGFUSE_S3_EVENT_UPLOAD_SECRET_ACCESS_KEY: minio12345
+      LANGFUSE_S3_EVENT_UPLOAD_ENDPOINT: http://minio:9000
+      LANGFUSE_S3_EVENT_UPLOAD_FORCE_PATH_STYLE: "true"
+      LANGFUSE_S3_EVENT_UPLOAD_PREFIX: "events/"
+      REDIS_HOST: langfuse-redis
+      REDIS_PORT: 6379
+      REDIS_AUTH: langfuse123
+      LANGFUSE_INIT_ORG_ID: ${LANGFUSE_INIT_ORG_ID:-dawn-ai}
+      LANGFUSE_INIT_ORG_NAME: ${LANGFUSE_INIT_ORG_NAME:-Dawn AI}
+      LANGFUSE_INIT_PROJECT_ID: ${LANGFUSE_INIT_PROJECT_ID:-dawn-ai}
+      LANGFUSE_INIT_PROJECT_NAME: ${LANGFUSE_INIT_PROJECT_NAME:-dawn-ai}
+      LANGFUSE_INIT_PROJECT_PUBLIC_KEY: ${LANGFUSE_INIT_PROJECT_PUBLIC_KEY:-pk-lf-dawn-dev}
+      LANGFUSE_INIT_PROJECT_SECRET_KEY: ${LANGFUSE_INIT_PROJECT_SECRET_KEY:-sk-lf-dawn-dev}
+      LANGFUSE_INIT_USER_EMAIL: ${LANGFUSE_INIT_USER_EMAIL:-admin@dawn.local}
+      LANGFUSE_INIT_USER_PASSWORD: ${LANGFUSE_INIT_USER_PASSWORD:-dawn-admin-123}
+      LANGFUSE_INIT_USER_NAME: ${LANGFUSE_INIT_USER_NAME:-Dawn Admin}
+    healthcheck:
+      test: ["CMD", "wget", "-q", "--spider", "http://localhost:3000/api/public/health"]
+      interval: 15s
+      timeout: 5s
+      retries: 20
+      start_period: 60s
+    networks:
+      - dawn-network
+```
+
+- [ ] **Step 2: Add the 4 new named volumes**
+
+Modify the `volumes:` block at the bottom — add `langfuse_postgres_data`, `langfuse_redis_data`, `clickhouse_data`, `minio_data`:
+
+```yaml
+volumes:
+  huggingface_cache:
+  postgres_data:
+  redis_data:
+  grafana_data:
+  langfuse_postgres_data:
+  clickhouse_data:
+  langfuse_redis_data:
+  minio_data:
+```
+
+- [ ] **Step 3: Verify YAML and bring up the stack**
+
+Run:
+```bash
+docker compose config --quiet && echo "YAML OK"
+docker compose up -d langfuse-postgres langfuse-redis clickhouse minio
+```
+Expected: `YAML OK`, then 4 containers running.
+
+```bash
+docker compose up -d langfuse-worker langfuse-web
+sleep 60
+docker compose ps langfuse-web
+curl -fsS http://localhost:3001/api/public/health && echo OK
+```
+Expected: `langfuse-web` shows `(healthy)`, curl returns `OK`.
+
+- [ ] **Step 4: Smoke-test the OTLP endpoint exists**
+
+Run:
+```bash
+curl -s -o /dev/null -w "%{http_code}\n" \
+  -X POST http://localhost:3001/api/public/otel/v1/traces \
+  -H "Content-Type: application/x-protobuf"
+```
+Expected: `401` (rejects unauthenticated, but proves the route exists). NOT `404`.
+
+If 404: Langfuse v3 OTLP not enabled — re-check image tag is `:3`, not `:2`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add docker-compose.yml
+git commit -m "feat(langfuse): add Langfuse v3 stack to docker-compose
+
+6 new services (langfuse-web/worker, langfuse-postgres, clickhouse,
+langfuse-redis, minio) on dawn-network. langfuse-web mapped to host:3001
+to avoid Grafana on 3000. ClickHouse/Redis/MinIO are internal-only."
+```
+
+---
+
+## Task 2: Add Langfuse env vars and helper script
+
+**Files:**
+- Modify: `.env.example`
+- Create: `scripts/langfuse-auth-header.sh`
+
+- [ ] **Step 1: Append Langfuse block to `.env.example`**
+
+Append at the end of `.env.example`:
+
+```dotenv
+
+# ───────── Langfuse (observability) ─────────
+# Bootstrap creds — change for non-local use. langfuse-web auto-creates
+# the org/project/user with these values on first start.
+LANGFUSE_INIT_ORG_ID=dawn-ai
+LANGFUSE_INIT_ORG_NAME=Dawn AI
+LANGFUSE_INIT_PROJECT_ID=dawn-ai
+LANGFUSE_INIT_PROJECT_NAME=dawn-ai
+LANGFUSE_INIT_PROJECT_PUBLIC_KEY=pk-lf-dawn-dev
+LANGFUSE_INIT_PROJECT_SECRET_KEY=sk-lf-dawn-dev
+LANGFUSE_INIT_USER_EMAIL=admin@dawn.local
+LANGFUSE_INIT_USER_PASSWORD=dawn-admin-123
+LANGFUSE_INIT_USER_NAME=Dawn Admin
+
+# OTLP exporter (read by dawn-ai application.yml)
+# Default endpoint targets the langfuse-web container over dawn-network.
+LANGFUSE_OTLP_ENDPOINT=http://langfuse-web:3000/api/public/otel/v1/traces
+# base64(LANGFUSE_INIT_PROJECT_PUBLIC_KEY:LANGFUSE_INIT_PROJECT_SECRET_KEY)
+# Generate with: scripts/langfuse-auth-header.sh
+LANGFUSE_AUTH_BASE64=cGstbGYtZGF3bi1kZXY6c2stbGYtZGF3bi1kZXY=
+LANGFUSE_ENVIRONMENT=dev
+```
+
+- [ ] **Step 2: Create `scripts/langfuse-auth-header.sh`**
+
+Create file with mode 755:
+
+```bash
+#!/usr/bin/env bash
+# Generate the value of LANGFUSE_AUTH_BASE64 used by the OTLP exporter.
+# Reads LANGFUSE_INIT_PROJECT_PUBLIC_KEY / SECRET_KEY from .env (or env).
+set -euo pipefail
+
+if [[ -f .env ]]; then
+  set -a; source .env; set +a
+fi
+
+: "${LANGFUSE_INIT_PROJECT_PUBLIC_KEY:?missing LANGFUSE_INIT_PROJECT_PUBLIC_KEY}"
+: "${LANGFUSE_INIT_PROJECT_SECRET_KEY:?missing LANGFUSE_INIT_PROJECT_SECRET_KEY}"
+
+printf '%s:%s' \
+  "$LANGFUSE_INIT_PROJECT_PUBLIC_KEY" \
+  "$LANGFUSE_INIT_PROJECT_SECRET_KEY" \
+  | base64
+```
+
+Then:
+```bash
+chmod +x scripts/langfuse-auth-header.sh
+```
+
+- [ ] **Step 3: Verify script output matches the value baked into `.env.example`**
+
+Run:
+```bash
+LANGFUSE_INIT_PROJECT_PUBLIC_KEY=pk-lf-dawn-dev \
+LANGFUSE_INIT_PROJECT_SECRET_KEY=sk-lf-dawn-dev \
+  scripts/langfuse-auth-header.sh
+```
+Expected: `cGstbGYtZGF3bi1kZXY6c2stbGYtZGF3bi1kZXY=` (matches `.env.example`).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .env.example scripts/langfuse-auth-header.sh
+git commit -m "feat(langfuse): add env vars and auth-header helper script"
+```
+
+---
+
+## Task 3: Add Maven dependencies
+
+**Files:**
+- Modify: `pom.xml`
+
+- [ ] **Step 1: Add the two dependencies**
+
+Locate the `<dependencies>` block in `pom.xml`. Add right after the existing `micrometer-registry-prometheus` dependency:
+
+```xml
+        <!-- Micrometer Tracing → OpenTelemetry bridge -->
+        <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-tracing-bridge-otel</artifactId>
+        </dependency>
+
+        <!-- OpenTelemetry OTLP exporter (HTTP/Protobuf) -->
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-exporter-otlp</artifactId>
+        </dependency>
+```
+
+(Versions managed by `spring-boot-starter-parent` 3.2.5 — no explicit `<version>` needed.)
+
+- [ ] **Step 2: Verify the build resolves**
+
+Run:
+```bash
+mvn -q -DskipTests dependency:resolve | tail -20
+mvn -q -DskipTests compile
+```
+Expected: BUILD SUCCESS, no "could not resolve" errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add pom.xml
+git commit -m "feat(langfuse): add micrometer-tracing-bridge-otel + opentelemetry-exporter-otlp"
+```
+
+---
+
+## Task 4: Add tracing/OTLP/observation config to application.yml
+
+**Files:**
+- Modify: `src/main/resources/application.yml`
+
+- [ ] **Step 1: Extend `management:` block with tracing + otlp**
+
+Replace the current `management:` block (lines starting at 62) with:
+
+```yaml
+# Actuator & Prometheus Metrics + OTLP tracing → Langfuse
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health, info, prometheus, metrics
+  endpoint:
+    health:
+      show-details: always
+  metrics:
+    export:
+      prometheus:
+        enabled: true
+  tracing:
+    sampling:
+      probability: 1.0
+  otlp:
+    tracing:
+      endpoint: ${LANGFUSE_OTLP_ENDPOINT:http://localhost:3001/api/public/otel/v1/traces}
+      compression: gzip
+      headers:
+        Authorization: Basic ${LANGFUSE_AUTH_BASE64:}
+```
+
+- [ ] **Step 2: Enable Spring AI prompt/completion/tool content logging**
+
+Add the following under the existing `spring.ai:` block (insert after the `vectorstore:` section, still within `spring.ai:`):
+
+```yaml
+    chat:
+      observations:
+        log-prompt: true
+        log-completion: true
+    tools:
+      observations:
+        include-content: true
+```
+
+- [ ] **Step 3: Add `langfuse:` top-level block (read by the resource customizer)**
+
+Append at the end of the file:
+
+```yaml
+# Langfuse environment label, attached as OTel resource attribute
+langfuse:
+  environment: ${LANGFUSE_ENVIRONMENT:dev}
+```
+
+- [ ] **Step 4: Verify YAML parses**
+
+Run:
+```bash
+mvn -q -DskipTests spring-boot:run -Dspring-boot.run.arguments="--spring.config.activate.on-profile=lint --spring.main.web-application-type=none --spring.main.lazy-initialization=true" &
+APP_PID=$!
+sleep 12
+kill $APP_PID 2>/dev/null || true
+```
+
+Easier alt — just compile and let Spring's strict YAML parser catch it on next test run. Skip this step if `mvn compile` already passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/main/resources/application.yml
+git commit -m "feat(langfuse): wire OTLP tracing + Spring AI observation content logging
+
+- management.tracing.sampling.probability=1.0 (dev)
+- management.otlp.tracing endpoint/headers/gzip
+- spring.ai.chat.observations.log-prompt/completion=true
+- spring.ai.tools.observations.include-content=true
+- langfuse.environment label"
+```
+
+---
+
+## Task 5: Write failing test for `LangfuseObservationConfig` filter
+
+**Files:**
+- Create: `src/test/java/com/dawn/ai/config/LangfuseObservationConfigTest.java`
+
+- [ ] **Step 1: Write the test**
+
+Create the file:
+
+```java
+package com.dawn.ai.config;
+
+import io.micrometer.common.KeyValue;
+import io.micrometer.observation.Observation;
+import io.micrometer.observation.ObservationFilter;
+import io.micrometer.observation.ObservationRegistry;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class LangfuseObservationConfigTest {
+
+    private final LangfuseObservationConfig config = new LangfuseObservationConfig();
+
+    @AfterEach
+    void clear() {
+        AiInteractionContext.clear();
+    }
+
+    @Test
+    void filterEmitsSessionIdWhenContextHasOne() {
+        AiInteractionContext.setSessionId("sess-123");
+        ObservationFilter filter = config.langfuseSessionFilter();
+
+        Observation.Context ctx = newContext();
+        filter.map(ctx);
+
+        assertThat(ctx.getLowCardinalityKeyValues())
+                .contains(KeyValue.of("session.id", "sess-123"));
+    }
+
+    @Test
+    void filterEmitsNothingWhenContextEmpty() {
+        ObservationFilter filter = config.langfuseSessionFilter();
+
+        Observation.Context ctx = newContext();
+        filter.map(ctx);
+
+        assertThat(ctx.getLowCardinalityKeyValues())
+                .noneMatch(kv -> kv.getKey().equals("session.id"));
+    }
+
+    @Test
+    void filterIgnoresBlankSessionId() {
+        AiInteractionContext.setSessionId("   ");
+        ObservationFilter filter = config.langfuseSessionFilter();
+
+        Observation.Context ctx = newContext();
+        filter.map(ctx);
+
+        assertThat(ctx.getLowCardinalityKeyValues())
+                .noneMatch(kv -> kv.getKey().equals("session.id"));
+    }
+
+    private Observation.Context newContext() {
+        Observation.Context ctx = new Observation.Context();
+        ctx.setName("test.observation");
+        return ctx;
+    }
+}
+```
+
+> Note: `AiInteractionContext.setSessionId(blank)` already calls `remove()` per its existing implementation, so the third test asserts the *resulting* behavior (no `session.id` emitted) regardless of which layer enforces it.
+
+- [ ] **Step 2: Run test — must FAIL**
+
+Run:
+```bash
+mvn -q -Dtest=LangfuseObservationConfigTest test
+```
+Expected: compilation FAIL — `LangfuseObservationConfig` does not exist.
+
+---
+
+## Task 6: Implement `LangfuseObservationConfig`
+
+**Files:**
+- Create: `src/main/java/com/dawn/ai/config/LangfuseObservationConfig.java`
+
+- [ ] **Step 1: Implement the class**
+
+Create:
+
+```java
+package com.dawn.ai.config;
+
+import io.micrometer.common.KeyValue;
+import io.micrometer.observation.ObservationFilter;
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.sdk.autoconfigure.spi.AutoConfigurationCustomizerProvider;
+import io.opentelemetry.sdk.resources.Resource;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Wires dawn-ai's existing per-thread sessionId into Spring AI's
+ * Micrometer Observations so Langfuse can group traces by chat session,
+ * and labels every exported span with a process-wide environment tag.
+ */
+@Configuration
+public class LangfuseObservationConfig {
+
+    /**
+     * Per-span filter: stamps {@code session.id} on every Observation when
+     * a sessionId is present on the current thread (already propagated by
+     * {@link AiInteractionContextAccessor} across Reactor / executor handoffs).
+     * {@code session.id} is the documented Langfuse OTel attribute that drives
+     * the Sessions view.
+     */
+    @Bean
+    public ObservationFilter langfuseSessionFilter() {
+        return ctx -> {
+            String sid = AiInteractionContext.getSessionId();
+            if (sid != null && !sid.isBlank()) {
+                ctx.addLowCardinalityKeyValue(KeyValue.of("session.id", sid));
+            }
+            return ctx;
+        };
+    }
+
+    /**
+     * Process-wide OTel resource attribute. Set once at SDK init rather than
+     * per-span so it doesn't bloat every span payload.
+     */
+    @Bean
+    public AutoConfigurationCustomizerProvider langfuseResourceCustomizer(
+            @Value("${langfuse.environment:dev}") String env) {
+        return customizer -> customizer.addResourceCustomizer((resource, props) ->
+                resource.merge(Resource.create(Attributes.of(
+                        AttributeKey.stringKey("langfuse.environment"), env))));
+    }
+}
+```
+
+- [ ] **Step 2: Run the unit test — must PASS**
+
+Run:
+```bash
+mvn -q -Dtest=LangfuseObservationConfigTest test
+```
+Expected: 3 tests, BUILD SUCCESS.
+
+- [ ] **Step 3: Run full test suite to ensure no regression**
+
+Run:
+```bash
+mvn -q test
+```
+Expected: BUILD SUCCESS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/main/java/com/dawn/ai/config/LangfuseObservationConfig.java \
+        src/test/java/com/dawn/ai/config/LangfuseObservationConfigTest.java
+git commit -m "feat(langfuse): inject session.id ObservationFilter + langfuse.environment OTel resource
+
+Per-span session.id is read from the existing AiInteractionContext
+(already propagated across Reactor / boundedElastic by
+AiInteractionContextAccessor). langfuse.environment is set as a
+process-wide OTel resource attribute via SDK customizer."
+```
+
+---
+
+## Task 7: Wire app container env so it reaches Langfuse over the dawn-network
+
+**Files:**
+- Modify: `docker-compose.yml`
+
+- [ ] **Step 1: Add 3 env vars to the `app:` service environment**
+
+In the `app:` service `environment:` block, append:
+
+```yaml
+      - LANGFUSE_OTLP_ENDPOINT=${LANGFUSE_OTLP_ENDPOINT:-http://langfuse-web:3000/api/public/otel/v1/traces}
+      - LANGFUSE_AUTH_BASE64=${LANGFUSE_AUTH_BASE64}
+      - LANGFUSE_ENVIRONMENT=${LANGFUSE_ENVIRONMENT:-dev}
+```
+
+> NOTE: do **NOT** add Langfuse services to `app.depends_on`. Per spec §9, the
+> business app must boot independently of the observability stack — early traces
+> are dropped silently if langfuse-web is not yet ready.
+
+- [ ] **Step 2: Validate compose**
+
+Run:
+```bash
+docker compose config --quiet && echo OK
+```
+Expected: `OK`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docker-compose.yml
+git commit -m "feat(langfuse): pass OTLP endpoint + auth + env to app container"
+```
+
+---
+
+## Task 8: End-to-end verification
+
+**Files:** none (manual verification)
+
+- [ ] **Step 1: Bring up the full stack**
+
+Run:
+```bash
+docker compose down
+docker compose up -d
+sleep 75
+docker compose ps
+```
+Expected: every container shows `(healthy)` or `Up`. `langfuse-web` is `(healthy)`.
+
+- [ ] **Step 2: Sanity-check Langfuse UI**
+
+```bash
+open http://localhost:3001    # macOS
+```
+Log in with `admin@dawn.local` / `dawn-admin-123`. Project `dawn-ai` should be pre-created.
+
+- [ ] **Step 3: Trigger one chat round trip**
+
+Run:
+```bash
+curl -s -X POST http://localhost:8080/api/v1/chat \
+  -H 'Content-Type: application/json' \
+  -d '{"message":"What is 2+2?","sessionId":"smoke-001"}' | jq .
+```
+Expected: HTTP 200, JSON body with an answer.
+
+- [ ] **Step 4: Verify trace appears in Langfuse**
+
+Wait ~5 seconds. In Langfuse UI:
+
+1. **Tracing** → see a new trace within 5–10 s.
+2. Open the trace → root span has model name, latency, token counts, **prompt + completion text visible**.
+3. Child spans visible for advisor / vector-store query / embedding (depending on chat path).
+4. Trace attribute panel shows `session.id = smoke-001` and `langfuse.environment = dev`.
+5. **Sessions** view (left nav) → session `smoke-001` is listed and groups the trace.
+
+- [ ] **Step 5: Verify resilience — Langfuse down does NOT break the app**
+
+Run:
+```bash
+docker compose stop langfuse-web langfuse-worker
+sleep 3
+curl -s -X POST http://localhost:8080/api/v1/chat \
+  -H 'Content-Type: application/json' \
+  -d '{"message":"ping","sessionId":"smoke-002"}' -w "\nHTTP %{http_code}\n"
+docker compose start langfuse-web langfuse-worker
+```
+Expected: HTTP 200 (chat succeeds even with Langfuse down).
+
+- [ ] **Step 6: Verify Prometheus pipeline still healthy (no regression)**
+
+Run:
+```bash
+curl -s http://localhost:8080/actuator/prometheus | head -20
+curl -s http://localhost:9090/-/healthy
+```
+Expected: prometheus exposition format text; `Prometheus Server is Healthy.`.
+
+---
+
+## Task 9: Update README
+
+**Files:**
+- Modify: `README.md`
+
+- [ ] **Step 1: Append observability section**
+
+Append at the end of `README.md`:
+
+```markdown
+
+## 📊 Observability with Langfuse
+
+`docker compose up` brings up a self-hosted **Langfuse v3** stack alongside
+the app. Every Spring AI call (chat, embedding, vector-store, tool-call)
+is exported via OTLP to Langfuse — full prompt, completion, and tool I/O
+included.
+
+### First run
+
+```bash
+cp .env.example .env
+# (Optional) regenerate the auth header if you change keys:
+scripts/langfuse-auth-header.sh    # paste output into LANGFUSE_AUTH_BASE64
+
+docker compose up -d
+```
+
+Visit **http://localhost:3001** and log in:
+
+| Field | Value (defaults from `.env.example`) |
+|---|---|
+| Email | `admin@dawn.local` |
+| Password | `dawn-admin-123` |
+
+The `dawn-ai` project is auto-created. New chats appear under **Tracing**
+within seconds; the **Sessions** tab groups traces by the `sessionId` you
+pass in the chat request body.
+
+### What goes where
+
+| Stack | Purpose | UI |
+|---|---|---|
+| **Prometheus + Grafana** (existing) | Aggregate metrics, RED, SLOs | http://localhost:3000 |
+| **Langfuse** (new) | Per-request traces, prompts, tool I/O | http://localhost:3001 |
+
+The two are independent — Langfuse downtime never affects the app.
+
+### Rotating keys / production
+
+Change `LANGFUSE_INIT_PROJECT_PUBLIC_KEY` and `_SECRET_KEY` in `.env`,
+re-run `scripts/langfuse-auth-header.sh`, paste the new value into
+`LANGFUSE_AUTH_BASE64`, then `docker compose up -d --force-recreate
+langfuse-web app`.
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add README.md
+git commit -m "docs(langfuse): document observability stack, first-run, and key rotation"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage check:**
+
+| Spec section | Implementing task |
+|---|---|
+| §4 Architecture diagram | Tasks 1, 3, 4, 6 |
+| §5 Component inventory & ports | Task 1 |
+| §6.1 New env vars | Task 2 |
+| §6.2 application.yml additions | Task 4 |
+| §6.3 Maven dependencies | Task 3 |
+| §7.1 LangfuseObservationConfig | Tasks 5, 6 |
+| §7.2 No edits to existing classes | Tasks 5–6 honor this (only new files) |
+| §8 Acceptance verification | Task 8 |
+| §9 Failure modes (no depends_on) | Task 7 step 1 NOTE; Task 8 step 5 |
+| §10 Documentation (README, .env.example, helper script) | Tasks 2, 9 |
+
+All spec items mapped — no gaps.
+
+**Placeholder scan:** No "TBD", no "implement later", every code block contains the actual code. ✔
+
+**Type consistency:** `langfuseSessionFilter()` and `langfuseResourceCustomizer()` bean names match between Tasks 5 (test) and 6 (impl). `LANGFUSE_AUTH_BASE64`, `LANGFUSE_OTLP_ENDPOINT`, `LANGFUSE_ENVIRONMENT` env names consistent across Tasks 1, 2, 4, 7. ✔
+
+---
+
+## Execution Handoff
+
+Plan complete and saved to `docs/superpowers/plans/2026-05-11-langfuse-integration.md`. Two execution options:
+
+1. **Subagent-Driven (recommended)** — I dispatch a fresh subagent per task, review between tasks, fast iteration.
+2. **Inline Execution** — Execute tasks in this session using executing-plans, batch execution with checkpoints.
+
+Which approach?

--- a/docs/superpowers/specs/2026-05-11-langfuse-integration-design.md
+++ b/docs/superpowers/specs/2026-05-11-langfuse-integration-design.md
@@ -73,9 +73,9 @@ OpenTelemetry SDK + OTLP/HTTP Exporter
 | langfuse-web | `langfuse/langfuse:3` | **3001** | 3000 | Web UI + OTLP ingestion endpoint. Grafana already owns 3000. |
 | langfuse-worker | `langfuse/langfuse-worker:3` | – | – | Internal-only |
 | langfuse-postgres | `postgres:16-alpine` | 5433 | 5432 | Isolated from business `postgres` (5432) |
-| clickhouse | `clickhouse/clickhouse-server:24.3` | 8123 / 9000 | 8123 / 9000 | Required by Langfuse v3 |
-| langfuse-redis | `redis:7-alpine` | 6380 | 6379 | Isolated from business `redis` (6379) |
-| minio | `minio/minio:latest` | 9100 / 9101 | 9000 / 9001 | S3-compatible blob store |
+| clickhouse | `clickhouse/clickhouse-server:24.3` | – | 8123 / 9000 | **Internal-only** — only consumed by langfuse-web/worker, no host exposure to keep dev port surface small |
+| langfuse-redis | `redis:7-alpine` | – | 6379 | **Internal-only** — only consumed by langfuse stack |
+| minio | `minio/minio:latest` | – | 9000 / 9001 | **Internal-only** — only consumed by langfuse stack |
 
 All services join the existing `dawn-network` bridge. New named volumes:
 `langfuse_postgres_data`, `clickhouse_data`, `langfuse_redis_data`, `minio_data`.
@@ -112,6 +112,7 @@ management:
   otlp:
     tracing:
       endpoint: ${LANGFUSE_OTLP_ENDPOINT:http://localhost:3001/api/public/otel/v1/traces}
+      compression: gzip
       headers:
         Authorization: Basic ${LANGFUSE_AUTH_BASE64:}
 
@@ -139,26 +140,41 @@ spring:
 
 ### 7.1 `LangfuseObservationConfig` (new)
 
-A single `@Configuration` class registering one `ObservationFilter`:
+A single `@Configuration` class with two beans:
+
+**(a) Per-span session filter** — injects `session.id` from
+`AiInteractionContext` onto every observation:
 
 ```java
 @Bean
-ObservationFilter langfuseSessionFilter(
-        @Value("${langfuse.environment:dev}") String env) {
+ObservationFilter langfuseSessionFilter() {
     return ctx -> {
         String sid = AiInteractionContext.getSessionId();
         if (sid != null && !sid.isBlank()) {
             ctx.addLowCardinalityKeyValue(KeyValue.of("session.id", sid));
         }
-        ctx.addLowCardinalityKeyValue(KeyValue.of("langfuse.environment", env));
         return ctx;
     };
 }
 ```
 
-The filter mutates every `Observation.Context`; bridge converts low-cardinality
-KeyValues to OTel span attributes; Langfuse picks up `session.id` natively
-(documented Langfuse OTel attribute) to drive the **Sessions** view.
+**(b) Static resource attribute** — `langfuse.environment` is process-wide
+(not per-span), so it is set as an OTel **resource attribute** via the
+SDK customizer instead of polluting every span:
+
+```java
+@Bean
+OpenTelemetryConfigurer langfuseResourceCustomizer(
+        @Value("${langfuse.environment:dev}") String env) {
+    return otel -> otel.addResourceCustomizer((res, cfg) ->
+        res.merge(Resource.create(Attributes.of(
+            AttributeKey.stringKey("langfuse.environment"), env))));
+}
+```
+
+The bridge converts low-cardinality KeyValues to OTel span attributes;
+Langfuse picks up `session.id` natively (documented Langfuse OTel attribute)
+to drive the **Sessions** view.
 
 ### 7.2 No edits to existing classes
 
@@ -191,7 +207,7 @@ KeyValues to OTel span attributes; Langfuse picks up `session.id` natively
 |---------|----------|-----------|
 | Langfuse stack down | OTLP exporter retries with backoff, eventually drops spans. App requests **succeed**. | OTel SDK default behavior; explicit `otel.exporter.otlp.timeout=10s`. |
 | Wrong `LANGFUSE_AUTH_BASE64` | 401 from ingestion endpoint, spans dropped. | Logged at WARN once per minute (OTel internal logger). |
-| First-run bootstrap race | langfuse-web may need 30–60 s after pg/clickhouse ready. | App `depends_on: langfuse-web (service_started)` only — app does NOT block on healthy, so missing first traces are tolerated. |
+| First-run bootstrap race | langfuse-web may need 30–60 s after pg/clickhouse ready. | App **does NOT** declare `depends_on` on the Langfuse stack at all — observability failure must never block business boot. Early traces (before langfuse-web is up) are dropped silently by the OTel exporter. |
 | ClickHouse / MinIO disk full | langfuse-worker stops persisting | Out of scope for dev; documented in README. |
 
 ## 10. Documentation Changes

--- a/docs/superpowers/specs/2026-05-11-langfuse-integration-design.md
+++ b/docs/superpowers/specs/2026-05-11-langfuse-integration-design.md
@@ -1,0 +1,233 @@
+# Langfuse Observability Integration — Design Spec
+
+- **Date**: 2026-05-11
+- **Branch**: `feat/langfuse-integration`
+- **Status**: Draft (pending spec review + user sign-off)
+- **Owner**: Supremes
+
+## 1. Goal
+
+Add end-to-end LLM observability to dawn-ai by self-hosting **Langfuse v3** in
+the existing `docker-compose.yml` and shipping all Spring AI Observation spans
+(chat, embedding, vector store, advisor, tool-calling) to Langfuse via the
+**OTLP/HTTP** protocol. Sessions in the Langfuse UI must aggregate by the
+existing `sessionId` carried in `AiInteractionContext`.
+
+## 2. Non-Goals
+
+- No production deployment topology (this spec covers local-dev only;
+  prod hardening is a separate workstream).
+- No Langfuse prompt-management, evaluation, or playground features. Only
+  tracing/observability.
+- No replacement of the existing `agent/trace` (`AgentStep` /
+  `StepCollector` / `ToolExecutionAspect`) module — that records
+  business-level step timelines and stays untouched.
+- No replacement of Prometheus/Grafana metrics — they continue to serve
+  RED metrics; Langfuse owns LLM-specific traces.
+
+## 3. Decisions Locked-In via Brainstorming
+
+| # | Decision | Choice |
+|---|----------|--------|
+| 1 | Integration path | **OTel**: Spring AI Observation → Micrometer → OTLP exporter → Langfuse OTLP endpoint |
+| 2 | Langfuse hosting | **Self-host v3 in docker-compose**, fully isolated from business pg/redis |
+| 3 | Data granularity | **Full prompt + completion + tool I/O** (`spring.ai.chat.observations.log-prompt/completion=true`, `spring.ai.tools.observations.include-content=true`); 100% sampling in dev |
+| 4 | sessionId correlation | **Enabled** — `ObservationFilter` reads `AiInteractionContext.getSessionId()` and emits OTel attribute `session.id` |
+| 5 | First-run UX | **Auto-bootstrap** via `LANGFUSE_INIT_*` env (org/project/user/keys created on first start) |
+
+## 4. Architecture
+
+```
+dawn-ai (Spring Boot 3.2 + Spring AI 1.1)
+   │
+   │  Spring AI Observation (built-in instrumentation:
+   │     ChatModel, EmbeddingModel, VectorStore, Advisor, ToolCalling)
+   ▼
+Micrometer ObservationRegistry
+   │  + LangfuseSessionObservationFilter
+   │       ↳ reads AiInteractionContext.getSessionId()
+   │       ↳ injects KeyValues: session.id, langfuse.environment
+   ▼
+micrometer-tracing-bridge-otel  (Span ↔ Observation bridge)
+   │
+   ▼
+OpenTelemetry SDK + OTLP/HTTP Exporter
+   │
+   │  POST  http://langfuse-web:3000/api/public/otel/v1/traces
+   │  Header  Authorization: Basic base64(public_key:secret_key)
+   ▼
+┌──────────────────────────── Langfuse v3 stack ────────────────────────────┐
+│  langfuse-web      (Next.js, ingestion + UI, host:3001 → container:3000)  │
+│  langfuse-worker   (background processor)                                 │
+│  langfuse-postgres (metadata, host:5433 → container:5432)                 │
+│  clickhouse        (trace columnar store, host:8123/9000)                 │
+│  langfuse-redis    (queues, host:6380 → container:6379)                   │
+│  minio             (S3-compatible object store, host:9100/9101)           │
+└────────────────────────────────────────────────────────────────────────────┘
+```
+
+## 5. Component Inventory & Port Allocation
+
+| Service | Image (pinned tag) | Host port | Internal port | Notes |
+|---------|--------------------|-----------|---------------|-------|
+| langfuse-web | `langfuse/langfuse:3` | **3001** | 3000 | Web UI + OTLP ingestion endpoint. Grafana already owns 3000. |
+| langfuse-worker | `langfuse/langfuse-worker:3` | – | – | Internal-only |
+| langfuse-postgres | `postgres:16-alpine` | 5433 | 5432 | Isolated from business `postgres` (5432) |
+| clickhouse | `clickhouse/clickhouse-server:24.3` | 8123 / 9000 | 8123 / 9000 | Required by Langfuse v3 |
+| langfuse-redis | `redis:7-alpine` | 6380 | 6379 | Isolated from business `redis` (6379) |
+| minio | `minio/minio:latest` | 9100 / 9101 | 9000 / 9001 | S3-compatible blob store |
+
+All services join the existing `dawn-network` bridge. New named volumes:
+`langfuse_postgres_data`, `clickhouse_data`, `langfuse_redis_data`, `minio_data`.
+
+## 6. Configuration Surface
+
+### 6.1 New environment variables (`.env.example`)
+
+```dotenv
+# --- Langfuse first-run bootstrap (langfuse-web container) ---
+LANGFUSE_INIT_ORG_ID=dawn-ai
+LANGFUSE_INIT_PROJECT_ID=dawn-ai
+LANGFUSE_INIT_PROJECT_PUBLIC_KEY=pk-lf-dawn-dev
+LANGFUSE_INIT_PROJECT_SECRET_KEY=sk-lf-dawn-dev
+LANGFUSE_INIT_USER_EMAIL=admin@dawn.local
+LANGFUSE_INIT_USER_PASSWORD=dawn-admin-123
+LANGFUSE_INIT_USER_NAME=Dawn Admin
+
+# --- dawn-ai → Langfuse OTLP exporter ---
+LANGFUSE_OTLP_ENDPOINT=http://langfuse-web:3000/api/public/otel/v1/traces
+LANGFUSE_AUTH_BASE64=<base64(LANGFUSE_INIT_PROJECT_PUBLIC_KEY:LANGFUSE_INIT_PROJECT_SECRET_KEY)>
+```
+
+> The base64 value is generated once by a helper script (`scripts/langfuse-auth-header.sh`)
+> and pasted into `.env`; documented in README.
+
+### 6.2 `application.yml` additions
+
+```yaml
+management:
+  tracing:
+    sampling:
+      probability: 1.0   # dev: full sampling
+  otlp:
+    tracing:
+      endpoint: ${LANGFUSE_OTLP_ENDPOINT:http://localhost:3001/api/public/otel/v1/traces}
+      headers:
+        Authorization: Basic ${LANGFUSE_AUTH_BASE64:}
+
+spring:
+  ai:
+    chat:
+      observations:
+        log-prompt: true
+        log-completion: true
+    tools:
+      observations:
+        include-content: true
+```
+
+### 6.3 New Maven dependencies (`pom.xml`)
+
+- `io.micrometer:micrometer-tracing-bridge-otel`
+- `io.opentelemetry:opentelemetry-exporter-otlp`
+
+(Spring Boot starter `actuator` already on the classpath provides
+`management.otlp.tracing.*` autoconfiguration. No need for the
+`opentelemetry-spring-boot-starter` — Spring Boot 3.2 actuator covers it.)
+
+## 7. Code Changes
+
+### 7.1 `LangfuseObservationConfig` (new)
+
+A single `@Configuration` class registering one `ObservationFilter`:
+
+```java
+@Bean
+ObservationFilter langfuseSessionFilter(
+        @Value("${langfuse.environment:dev}") String env) {
+    return ctx -> {
+        String sid = AiInteractionContext.getSessionId();
+        if (sid != null && !sid.isBlank()) {
+            ctx.addLowCardinalityKeyValue(KeyValue.of("session.id", sid));
+        }
+        ctx.addLowCardinalityKeyValue(KeyValue.of("langfuse.environment", env));
+        return ctx;
+    };
+}
+```
+
+The filter mutates every `Observation.Context`; bridge converts low-cardinality
+KeyValues to OTel span attributes; Langfuse picks up `session.id` natively
+(documented Langfuse OTel attribute) to drive the **Sessions** view.
+
+### 7.2 No edits to existing classes
+
+- `AiInteractionContext` already exposes `getSessionId()` — used as-is.
+- `AiInteractionContextAccessor` already registered for Reactor / executor
+  propagation — covers tool callbacks running on `boundedElastic`.
+- `agent/trace/*` untouched.
+- Controllers / services untouched.
+
+## 8. Data Flow Verification (Acceptance)
+
+1. `cp .env.example .env` and `./scripts/langfuse-auth-header.sh` to fill
+   `LANGFUSE_AUTH_BASE64`.
+2. `docker compose up -d` — all containers reach `healthy`.
+3. Visit `http://localhost:3001`, log in with `admin@dawn.local` /
+   `dawn-admin-123`, see `dawn-ai` project pre-created.
+4. `mvn spring-boot:run` (or `docker compose up app`).
+5. `curl -X POST localhost:8080/api/v1/chat -H 'Content-Type: application/json' \
+    -d '{"message":"hi","sessionId":"smoke-001"}'`
+6. In Langfuse UI → **Tracing**: a new trace appears within ≤5 s containing:
+   - root span `chat` (model, latency, tokens, full prompt + completion)
+   - child spans for advisor, vector-store query, embedding, tool calls
+     (with full I/O)
+   - attribute `session.id = smoke-001`
+7. **Sessions** view groups all traces with `sessionId = smoke-001`.
+
+## 9. Failure Modes & Handling
+
+| Failure | Behavior | Mitigation |
+|---------|----------|-----------|
+| Langfuse stack down | OTLP exporter retries with backoff, eventually drops spans. App requests **succeed**. | OTel SDK default behavior; explicit `otel.exporter.otlp.timeout=10s`. |
+| Wrong `LANGFUSE_AUTH_BASE64` | 401 from ingestion endpoint, spans dropped. | Logged at WARN once per minute (OTel internal logger). |
+| First-run bootstrap race | langfuse-web may need 30–60 s after pg/clickhouse ready. | App `depends_on: langfuse-web (service_started)` only — app does NOT block on healthy, so missing first traces are tolerated. |
+| ClickHouse / MinIO disk full | langfuse-worker stops persisting | Out of scope for dev; documented in README. |
+
+## 10. Documentation Changes
+
+- `README.md` — append new section **"📊 Observability (Langfuse)"**
+  with: how to start, default credentials, where to view traces, how to
+  rotate keys.
+- `docs/` — add this design spec (current file).
+- `.env.example` — add the variables listed in §6.1.
+- `scripts/langfuse-auth-header.sh` — small helper that prints
+  `base64(public:secret)` for the operator to paste into `.env`.
+
+## 11. Out-of-Scope / Follow-Ups
+
+- Production secret management (Vault / AWS Secrets Manager).
+- Trace sampling tuning for production (`probability=0.1` + tail sampling).
+- Langfuse RBAC / multi-tenant setup.
+- Wiring Langfuse evaluations & datasets into RAG eval workflow
+  (`rag/evaluation`) — natural follow-up but separate spec.
+- Replacing `agent/trace` with pure OTel spans — possible long-term
+  unification, not part of this PR.
+
+## 12. Risks
+
+- **Container footprint**: stack adds ~1.5 GB RAM + ~6 containers; Apple
+  Silicon dev machines should handle it but documented as a caveat.
+- **Spring AI Observation API drift**: 1.1 is the first stable line; if
+  property names move in a minor version, config must be re-checked. Pinned
+  version in `pom.xml` mitigates.
+- **Langfuse OTel endpoint stability**: `/api/public/otel/v1/traces` is
+  marked stable in Langfuse v3 (>= v3.0). We pin the `langfuse:3` tag.
+
+## 13. Rollout
+
+1. Merge `feat/langfuse-integration` to `master` after review.
+2. No DB migration, no breaking change for existing clients.
+3. Existing users running `docker compose up` get the new stack
+   automatically; opt-out is `docker compose up app postgres redis`
+   (explicit service list).

--- a/docs/superpowers/specs/2026-05-11-langfuse-integration-design.md
+++ b/docs/superpowers/specs/2026-05-11-langfuse-integration-design.md
@@ -1,39 +1,30 @@
-# Langfuse Observability Integration — Design Spec
+# Langfuse 可观测性集成 — 设计规格文档
 
-- **Date**: 2026-05-11
-- **Branch**: `feat/langfuse-integration`
-- **Status**: Draft (pending spec review + user sign-off)
-- **Owner**: Supremes
+- **日期**：2026-05-11
+- **分支**：`feat/langfuse-integration`
+- **状态**：草稿（待规格评审 + 用户确认）
+- **负责人**：Supremes
 
-## 1. Goal
+## 1. 目标
 
-Add end-to-end LLM observability to dawn-ai by self-hosting **Langfuse v3** in
-the existing `docker-compose.yml` and shipping all Spring AI Observation spans
-(chat, embedding, vector store, advisor, tool-calling) to Langfuse via the
-**OTLP/HTTP** protocol. Sessions in the Langfuse UI must aggregate by the
-existing `sessionId` carried in `AiInteractionContext`.
+通过在现有 `docker-compose.yml` 中自托管 **Langfuse v3**，为 dawn-ai 提供端到端 LLM 可观测性，并将所有 Spring AI Observation Span（chat、embedding、vector store、advisor、tool-calling）通过 **OTLP/HTTP** 协议推送到 Langfuse。Langfuse UI 中的 Sessions 视图须按 `AiInteractionContext` 中已有的 `sessionId` 进行聚合。
 
-## 2. Non-Goals
+## 2. 非目标（Non-Goals）
 
-- No production deployment topology (this spec covers local-dev only;
-  prod hardening is a separate workstream).
-- No Langfuse prompt-management, evaluation, or playground features. Only
-  tracing/observability.
-- No replacement of the existing `agent/trace` (`AgentStep` /
-  `StepCollector` / `ToolExecutionAspect`) module — that records
-  business-level step timelines and stays untouched.
-- No replacement of Prometheus/Grafana metrics — they continue to serve
-  RED metrics; Langfuse owns LLM-specific traces.
+- 不涉及生产环境部署拓扑（本规格仅覆盖本地开发；生产加固为独立工作流）。
+- 不使用 Langfuse 的 Prompt 管理、Evaluation 或 Playground 功能，仅使用 Tracing/Observability。
+- 不替换现有的 `agent/trace` 模块（`AgentStep` / `StepCollector` / `ToolExecutionAspect`）——该模块记录业务层步骤时间线，保持不动。
+- 不替换 Prometheus/Grafana 指标——它们继续提供 RED 指标；Langfuse 负责 LLM 专项 Trace。
 
-## 3. Decisions Locked-In via Brainstorming
+## 3. 已锁定决策
 
-| # | Decision | Choice |
-|---|----------|--------|
-| 1 | Integration path | **OTel**: Spring AI Observation → Micrometer → OTLP exporter → Langfuse OTLP endpoint |
-| 2 | Langfuse hosting | **Self-host v3 in docker-compose**, fully isolated from business pg/redis |
-| 3 | Data granularity | **Full prompt + completion + tool I/O** (`spring.ai.chat.observations.log-prompt/completion=true`, `spring.ai.tools.observations.include-content=true`); 100% sampling in dev |
-| 4 | sessionId correlation | **Enabled** — `ObservationFilter` reads `AiInteractionContext.getSessionId()` and emits OTel attribute `session.id` |
-| 5 | First-run UX | **Auto-bootstrap** via `LANGFUSE_INIT_*` env (org/project/user/keys created on first start) |
+| # | 决策项 | 选择 |
+|---|--------|------|
+| 1 | 集成路径 | **OTel**：Spring AI Observation → Micrometer → OTLP exporter → Langfuse OTLP 端点 |
+| 2 | Langfuse 托管方式 | **docker-compose 自托管 v3**，与业务 pg/redis 完全隔离 |
+| 3 | 数据粒度 | **完整 prompt + completion + tool I/O**（`spring.ai.chat.observations.log-prompt/completion=true`，`spring.ai.tools.observations.include-content=true`）；开发环境 100% 采样 |
+| 4 | sessionId 关联 | **已启用** — `ObservationFilter` 读取 `AiInteractionContext.getSessionId()` 并发射 OTel 属性 `session.id` |
+| 5 | 首次启动体验 | **自动初始化** — 通过 `LANGFUSE_INIT_*` 环境变量（首次启动时自动创建 org/project/user/key） |
 
 ## 4. Architecture
 
@@ -66,23 +57,22 @@ OpenTelemetry SDK + OTLP/HTTP Exporter
 └────────────────────────────────────────────────────────────────────────────┘
 ```
 
-## 5. Component Inventory & Port Allocation
+## 5. 组件清单与端口分配
 
-| Service | Image (pinned tag) | Host port | Internal port | Notes |
-|---------|--------------------|-----------|---------------|-------|
-| langfuse-web | `langfuse/langfuse:3` | **3001** | 3000 | Web UI + OTLP ingestion endpoint. Grafana already owns 3000. |
-| langfuse-worker | `langfuse/langfuse-worker:3` | – | – | Internal-only |
-| langfuse-postgres | `postgres:16-alpine` | 5433 | 5432 | Isolated from business `postgres` (5432) |
-| clickhouse | `clickhouse/clickhouse-server:24.3` | – | 8123 / 9000 | **Internal-only** — only consumed by langfuse-web/worker, no host exposure to keep dev port surface small |
-| langfuse-redis | `redis:7-alpine` | – | 6379 | **Internal-only** — only consumed by langfuse stack |
-| minio | `minio/minio:latest` | – | 9000 / 9001 | **Internal-only** — only consumed by langfuse stack |
+| 服务 | 镜像（锁定标签） | 宿主机端口 | 容器内端口 | 备注 |
+|-----|-----------------|-----------|-----------|------|
+| langfuse-web | `langfuse/langfuse:3` | **3001** | 3000 | Web UI + OTLP 摄入端点。Grafana 已占用 3000。 |
+| langfuse-worker | `langfuse/langfuse-worker:3` | – | – | 仅内部访问 |
+| langfuse-postgres | `postgres:16-alpine` | 5433 | 5432 | 与业务 `postgres`（5432）隔离 |
+| clickhouse | `clickhouse/clickhouse-server:24.3` | – | 8123 / 9000 | **仅内部访问** — 仅供 langfuse-web/worker 消费，不暴露到宿主机以减少开发端口占用 |
+| langfuse-redis | `redis:7-alpine` | – | 6379 | **仅内部访问** — 仅供 Langfuse 服务栈使用 |
+| minio | `minio/minio:latest` | – | 9000 / 9001 | **仅内部访问** — 仅供 Langfuse 服务栈使用 |
 
-All services join the existing `dawn-network` bridge. New named volumes:
-`langfuse_postgres_data`, `clickhouse_data`, `langfuse_redis_data`, `minio_data`.
+所有服务加入现有的 `dawn-network` 桥接网络。新增命名 Volume：`langfuse_postgres_data`、`clickhouse_data`、`langfuse_redis_data`、`minio_data`。
 
-## 6. Configuration Surface
+## 6. 配置项说明
 
-### 6.1 New environment variables (`.env.example`)
+### 6.1 新增环境变量（`.env.example`）
 
 ```dotenv
 # --- Langfuse first-run bootstrap (langfuse-web container) ---
@@ -99,10 +89,9 @@ LANGFUSE_OTLP_ENDPOINT=http://langfuse-web:3000/api/public/otel/v1/traces
 LANGFUSE_AUTH_BASE64=<base64(LANGFUSE_INIT_PROJECT_PUBLIC_KEY:LANGFUSE_INIT_PROJECT_SECRET_KEY)>
 ```
 
-> The base64 value is generated once by a helper script (`scripts/langfuse-auth-header.sh`)
-> and pasted into `.env`; documented in README.
+> base64 值由辅助脚本（`scripts/langfuse-auth-header.sh`）一次性生成后粘贴到 `.env` 中；详见 README。
 
-### 6.2 `application.yml` additions
+### 6.2 `application.yml` 新增配置
 
 ```yaml
 management:
@@ -127,23 +116,20 @@ spring:
         include-content: true
 ```
 
-### 6.3 New Maven dependencies (`pom.xml`)
+### 6.3 新增 Maven 依赖（`pom.xml`）
 
 - `io.micrometer:micrometer-tracing-bridge-otel`
 - `io.opentelemetry:opentelemetry-exporter-otlp`
 
-(Spring Boot starter `actuator` already on the classpath provides
-`management.otlp.tracing.*` autoconfiguration. No need for the
-`opentelemetry-spring-boot-starter` — Spring Boot 3.2 actuator covers it.)
+（`spring-boot-starter-parent` 3.2.5 已通过 `actuator` starter 提供 `management.otlp.tracing.*` 自动配置，无需引入 `opentelemetry-spring-boot-starter`。）
 
-## 7. Code Changes
+## 7. 代码变更
 
-### 7.1 `LangfuseObservationConfig` (new)
+### 7.1 `LangfuseObservationConfig`（新建）
 
-A single `@Configuration` class with two beans:
+一个 `@Configuration` 类，包含两个 Bean：
 
-**(a) Per-span session filter** — injects `session.id` from
-`AiInteractionContext` onto every observation:
+**（a）每 Span 会话过滤器** — 将 `AiInteractionContext` 中的 `session.id` 注入到每个 Observation：
 
 ```java
 @Bean
@@ -158,9 +144,7 @@ ObservationFilter langfuseSessionFilter() {
 }
 ```
 
-**(b) Static resource attribute** — `langfuse.environment` is process-wide
-(not per-span), so it is set as an OTel **resource attribute** via the
-SDK customizer instead of polluting every span:
+**（b）静态 Resource 属性** — `langfuse.environment` 是进程级全局配置（非每 Span），通过 SDK 定制器设置为 OTel **Resource Attribute**，避免污染每个 Span payload：
 
 ```java
 @Bean
@@ -172,138 +156,107 @@ OpenTelemetryConfigurer langfuseResourceCustomizer(
 }
 ```
 
-The bridge converts low-cardinality KeyValues to OTel span attributes;
-Langfuse picks up `session.id` natively (documented Langfuse OTel attribute)
-to drive the **Sessions** view.
+桥接层将低基数 KeyValue 转换为 OTel Span Attribute；Langfuse 原生识别 `session.id`（官方文档 OTel 属性），用于驱动 **Sessions** 视图。
 
-### 7.2 No edits to existing classes
+### 7.2 不修改现有类
 
-- `AiInteractionContext` already exposes `getSessionId()` — used as-is.
-- `AiInteractionContextAccessor` already registered for Reactor / executor
-  propagation — covers tool callbacks running on `boundedElastic`.
-- `agent/trace/*` untouched.
-- Controllers / services untouched.
+- `AiInteractionContext` 已暴露 `getSessionId()` — 直接复用。
+- `AiInteractionContextAccessor` 已注册用于 Reactor / executor 传播 — 覆盖运行在 `boundedElastic` 上的 Tool 回调。
+- `agent/trace/*` 保持不变。
+- Controllers / Services 保持不变。
 
-## 8. Data Flow Verification (Acceptance)
+## 8. 数据流验证（验收标准）
 
-1. `cp .env.example .env` and `./scripts/langfuse-auth-header.sh` to fill
-   `LANGFUSE_AUTH_BASE64`.
-2. `docker compose up -d` — all containers reach `healthy`.
-3. Visit `http://localhost:3001`, log in with `admin@dawn.local` /
-   `dawn-admin-123`, see `dawn-ai` project pre-created.
-4. `mvn spring-boot:run` (or `docker compose up app`).
-5. `curl -X POST localhost:8080/api/v1/chat -H 'Content-Type: application/json' \
-    -d '{"message":"hi","sessionId":"smoke-001"}'`
-6. In Langfuse UI → **Tracing**: a new trace appears within ≤5 s containing:
-   - root span `chat` (model, latency, tokens, full prompt + completion)
-   - child spans for advisor, vector-store query, embedding, tool calls
-     (with full I/O)
-   - attribute `session.id = smoke-001`
-7. **Sessions** view groups all traces with `sessionId = smoke-001`.
+1. 执行 `cp .env.example .env`，再执行 `./scripts/langfuse-auth-header.sh` 填充 `LANGFUSE_AUTH_BASE64`。
+2. `docker compose up -d` — 所有容器达到 `healthy` 状态。
+3. 访问 `http://localhost:3001`，以 `admin@dawn.local` / `dawn-admin-123` 登录，确认 `dawn-ai` 项目已预创建。
+4. 启动应用：`mvn spring-boot:run`（或 `docker compose up app`）。
+5. 发送测试请求：`curl -X POST localhost:8080/api/v1/chat -H 'Content-Type: application/json' -d '{"message":"hi","sessionId":"smoke-001"}'`
+6. 在 Langfuse UI → **Tracing** 中：5 秒内出现新 Trace，包含：
+   - 根 Span `chat`（模型名、延迟、Token 数、完整 prompt + completion）
+   - advisor、vector-store query、embedding、tool call 等子 Span（含完整 I/O）
+   - 属性 `session.id = smoke-001`
+7. **Sessions** 视图将所有 `sessionId = smoke-001` 的 Trace 聚合在一起。
 
-## 9. Failure Modes & Handling
+## 9. 故障模式与应对方案
 
-| Failure | Behavior | Mitigation |
-|---------|----------|-----------|
-| Langfuse stack down | OTLP exporter retries with backoff, eventually drops spans. App requests **succeed**. | OTel SDK default behavior; explicit `otel.exporter.otlp.timeout=10s`. |
-| Wrong `LANGFUSE_AUTH_BASE64` | 401 from ingestion endpoint, spans dropped. | Logged at WARN once per minute (OTel internal logger). |
-| First-run bootstrap race | langfuse-web may need 30–60 s after pg/clickhouse ready. | App **does NOT** declare `depends_on` on the Langfuse stack at all — observability failure must never block business boot. Early traces (before langfuse-web is up) are dropped silently by the OTel exporter. |
-| ClickHouse / MinIO disk full | langfuse-worker stops persisting | Out of scope for dev; documented in README. |
+| 故障 | 行为 | 应对措施 |
+|------|------|----------|
+| Langfuse 服务栈宕机 | OTLP exporter 指数退避重试，最终丢弃 Span。业务请求**仍然成功**。 | OTel SDK 默认行为；显式设置 `otel.exporter.otlp.timeout=10s`。 |
+| `LANGFUSE_AUTH_BASE64` 错误 | 摄入端点返回 401，Span 被丢弃。 | OTel 内部日志每分钟记录一次 WARN。 |
+| 首次启动初始化竞争 | langfuse-web 在 pg/clickhouse 就绪后可能需要 30–60 秒。 | 应用**不声明** Langfuse 服务栈的 `depends_on`——可观测性故障绝不能阻塞业务启动。langfuse-web 未就绪前的早期 Trace 由 OTel exporter 静默丢弃。 |
+| ClickHouse / MinIO 磁盘满 | langfuse-worker 停止持久化 | 开发环境超出范围；已在 README 中说明。 |
 
-## 10. Documentation Changes
+## 10. 文档变更
 
-- `README.md` — append new section **"📊 Observability (Langfuse)"**
-  with: how to start, default credentials, where to view traces, how to
-  rotate keys.
-- `docs/` — add this design spec (current file).
-- `.env.example` — add the variables listed in §6.1.
-- `scripts/langfuse-auth-header.sh` — small helper that prints
-  `base64(public:secret)` for the operator to paste into `.env`.
+- `README.md` — 追加新章节 **"📊 可观测性（Langfuse）"**，内容包含：如何启动、默认凭据、在哪里查看 Trace、如何更换密鑰。
+- `docs/` — 添加本设计规格文档（即当前文件）。
+- `.env.example` — 添加第 6.1 节列出的环境变量。
+- `scripts/langfuse-auth-header.sh` — 小型辅助脚本，输出 `base64(public:secret)` 以供操作者粘贴到 `.env`。
 
-## 11. Out-of-Scope / Follow-Ups
+## 11. 超出范围 / 后续事项
 
-- Production secret management (Vault / AWS Secrets Manager).
-- Trace sampling tuning for production (`probability=0.1` + tail sampling).
-- Langfuse RBAC / multi-tenant setup.
-- Wiring Langfuse evaluations & datasets into RAG eval workflow
-  (`rag/evaluation`) — natural follow-up but separate spec.
-- Replacing `agent/trace` with pure OTel spans — possible long-term
-  unification, not part of this PR.
+- 生产密钒管理（Vault / AWS Secrets Manager）。
+- 生产环境采样率调优（`probability=0.1` + 尾部采样）。
+- Langfuse RBAC / 多租户设置。
+- 将 Langfuse Evaluation & Datasets 接入 RAG 评估工作流（`rag/evaluation`）——自然后续项，单独立项。
+- 用纯粹 OTel Span 替换 `agent/trace` ——长期统一化可行，不在本 PR 范围内。
 
-## 12. Risks
+## 12. 风险
 
-- **Container footprint**: stack adds ~1.5 GB RAM + ~6 containers; Apple
-  Silicon dev machines should handle it but documented as a caveat.
-- **Spring AI Observation API drift**: 1.1 is the first stable line; if
-  property names move in a minor version, config must be re-checked. Pinned
-  version in `pom.xml` mitigates.
-- **Langfuse OTel endpoint stability**: `/api/public/otel/v1/traces` is
-  marked stable in Langfuse v3 (>= v3.0). We pin the `langfuse:3` tag.
+- **容器占用：** 服务栈新增 ~1.5 GB RAM + ~6 个容器；Apple Silicon 开发机应可承载，已在文档中说明注意事项。
+- **Spring AI Observation API 漂移：** 1.1 是首个稳定版本系列；如果属性名在小版本中更改，配置需重新检查。锁定 `pom.xml` 中的版本可降低风险。
+- **Langfuse OTel 端点稳定性：** `/api/public/otel/v1/traces` 在 Langfuse v3（>= v3.0）中标记为稳定。我们锁定 `langfuse:3` 标签。
 
-## 13. Rollout
+## 13. 上线流程
 
-1. Merge `feat/langfuse-integration` to `master` after review.
-2. No DB migration, no breaking change for existing clients.
-3. Existing users running `docker compose up` get the new stack
-   automatically; opt-out is `docker compose up app postgres redis`
-   (explicit service list).
+1. 审查通过后将 `feat/langfuse-integration` 合并到 `master`。
+2. 无 DB 迁移，对现有客户端无破坏性变更。
+3. 现有用户执行 `docker compose up` 将自动获得新服务栈；如需退出，可使用 `docker compose up app postgres redis`（显式指定服务列表）。
 
 ---
 
-## Appendix A — How Langfuse Integrates Without an Official Java SDK
+## 附录 A — 为何 Langfuse 无需官方 Java SDK 就能集成
 
-dawn-ai never imports a Langfuse client library. The integration is
-**protocol-level, not library-level**:
+dawn-ai 不导入任何 Langfuse 客户端库。集成方式是**协议层，而非库层**：
 
 ```
-[1] Spring AI 1.1 auto-instruments ChatModel / Embedding / VectorStore /
-    Advisor / Tool calls via the Micrometer Observation API (built-in,
-    nothing for us to add).
+[1] Spring AI 1.1 通过 Micrometer Observation API 自动埋点
+    ChatModel / Embedding / VectorStore / Advisor / Tool calls（内置，无需额外代码）。
 
-[2] micrometer-tracing-bridge-otel  translates Observation → OpenTelemetry Span.
+[2] micrometer-tracing-bridge-otel  将 Observation 转换为 OpenTelemetry Span。
 
-[3] opentelemetry-exporter-otlp     serializes Spans into OTLP
-    (HTTP + Protobuf, an open industry-standard protocol) and POSTs to
+[3] opentelemetry-exporter-otlp     将 Span 序列化为 OTLP
+    （HTTP + Protobuf，开放行业标准协议）并 POST 到
     http://langfuse-web:3000/api/public/otel/v1/traces
     Header: Authorization: Basic base64(public_key:secret_key)
 
-[4] Langfuse v3 server implements an OTLP-compatible ingestion endpoint
-    and decodes incoming OTel Spans into its internal
-    Trace / Observation / Generation model, persisted to ClickHouse.
+[4] Langfuse v3 服务端实现了兼容 OTLP 的摄入端点，
+    将传入的 OTel Span 解码为内部的
+    Trace / Observation / Generation 模型，持久化到 ClickHouse。
 ```
 
-**Why no SDK is needed**: Langfuse exposes itself as a standard OTLP
-trace backend. Any language with an OpenTelemetry exporter can talk to
-it. Analogous to: MySQL has no official Rust driver, but Rust programs
-connect because the MySQL Wire Protocol is public — clients only need
-to speak the protocol.
+**为何不需要 SDK**：Langfuse 将自身暴露为标准 OTLP Trace 后端。任何具备 OpenTelemetry exporter 的语言都能与其通信。类比：MySQL 没有官方 Rust 驱动，但 Rust 程序可以连接 MySQL，因为 MySQL 线路协议是公开的——客户端只需能说该协议即可。
 
-**Caveat**: span attribute names must follow Langfuse's documented OTel
-semantic conventions (`session.id`, `gen_ai.usage.input_tokens`,
-`gen_ai.prompt`, …) for the UI to interpret them correctly. This is why
-§7.1 explicitly emits `session.id` via an `ObservationFilter` — Spring
-AI does not emit it by default.
+**注意事项**：Span 属性名必须遵循 Langfuse 官方文档的 OTel 语义约定（`session.id`、`gen_ai.usage.input_tokens`、`gen_ai.prompt` 等），UI 才能正确解析。这就是为什么第 7.1 节要通过 `ObservationFilter` 显式发射 `session.id`——Spring AI 默认不发射它。
 
-> Langfuse also offers a **private** ingestion API (`/api/public/ingestion`,
-> custom JSON) that *does* require an SDK to consume. We deliberately
-> avoid it; OTLP gives us the same coverage with zero proprietary deps.
+> Langfuse 还提供一个**私有**摄入 API（`/api/public/ingestion`，自定义 JSON），该 API *确实*需要 SDK 才能消费。我们特意避开它；OTLP 能提供同等覆盖度，且零专有依赖。
 
 ---
 
-## Appendix B — OTLP / Langfuse vs. Prometheus + Grafana
+## 附录 B — OTLP / Langfuse vs. Prometheus + Grafana
 
-The two stacks address **different pillars of observability** and stay
-side-by-side, **not as replacements for each other**.
+两个服务栈分别解决**可观测性三大支柱中的不同部分**，并列**而不是互相替代**。
 
-### B.1 Three pillars
+### B.1 三大支柱
 
-| Pillar | Data shape | Question it answers | Owned by |
-|--------|------------|---------------------|----------|
-| **Metrics** | time-series numerics (counter / histogram) | "How fast/stable overall? P99? error rate?" | **Prometheus + Grafana** (existing) |
-| **Traces** | causally-linked span tree + context | "Why was **this one** request slow / wrong / expensive? What prompt? Which tools?" | **OTLP → Langfuse** (new) |
-| Logs | structured text | "What exactly happened at the moment of failure?" | logback (not centralized yet) |
+| 支柱 | 数据形态 | 回答的问题 | 归属 |
+|------|---------|------------|------|
+| **指标（Metrics）** | 时序数字（counter / histogram） | “整体多快多稳？P99？错误率？” | **Prometheus + Grafana**（现有） |
+| **链路跟踪（Traces）** | 因果关联的 Span 树 + 上下文 | “**这一个**请求为什么慢/错/贵？用了什么 Prompt？哪个 Tool？” | **OTLP → Langfuse**（新增） |
+| 日志（Logs） | 结构化文本 | “故障时刻具体发生了什么？” | logback（暂未集中化） |
 
-### B.2 Topology after integration
+### B.2 集成后的拓扑结构
 
 ```
                            dawn-ai (Spring Boot)
@@ -330,56 +283,45 @@ side-by-side, **not as replacements for each other**.
               │ Grafana        │
               └────────────────┘
                        ↑                       ↑
-              "Trends, SLOs,             "Per-session deep-dive:
-               aggregated rates"          prompt, tool calls,
-                                          why slow / costly"
+              "趋势、SLO、汇总指标"        "单会话深入分析：
+                                          Prompt、Tool 调用、
+                                          慢或贵的原因"
 ```
 
-### B.3 OTLP vs. Prometheus protocol — clarifying overlap
+### B.3 OTLP vs. Prometheus 协议对比
 
-| Aspect | Prometheus | OTLP |
-|--------|------------|------|
-| Standard owner | Prometheus project (CNCF) | OpenTelemetry (CNCF) |
-| Direction | Server **pulls** `/metrics` from app | App **pushes** to collector / backend |
-| Carries metrics? | Yes (its only purpose) | Yes — but we don't use this leg |
-| Carries traces? | No | **Yes** — what we use |
-| Carries logs? | No | Yes (optional) |
+| 维度 | Prometheus | OTLP |
+|------|------------|------|
+| 标准权属 | Prometheus 项目（CNCF） | OpenTelemetry（CNCF） |
+| 方向 | 服务端 **拉取** 应用的 `/metrics` | 应用**推送**到 collector / backend |
+| 传输指标？ | 是（唯一用途） | 是——但我们不使用此路 |
+| 传输链路？ | 否 | **是**——我们使用的部分 |
+| 传输日志？ | 否 | 是（可选） |
 
-OTLP can theoretically replace Prometheus for metrics too (via OTel
-Collector → `prometheus_remote_write`), but we **deliberately don't**:
-existing metrics pipeline is healthy; refactoring it brings no value
-and risks regression. This integration touches **only the trace leg**.
+OTLP 理论上也能替代 Prometheus 的指标职能（通过 OTel Collector → `prometheus_remote_write`），但我们**特意不这样做**：现有指标流水线运转良好；重构带不来价值且存在回归风险。本次集成仅涉及 **Trace 路**。
 
-### B.4 Same instrumentation, two outputs
+### B.4 同一埋点，两个输出
 
-A single piece of Micrometer instrumentation — e.g. Spring AI's
-`ChatModel` observation — feeds **both** sinks simultaneously:
+一段 Micrometer 埋点代码——例如 Spring AI 的 `ChatModel` Observation——同时向**两个汇流池**输出：
 
-- the `MeterRegistry` side emits histogram → Prometheus → Grafana
-  ("LLM call latency P99");
-- the `ObservationRegistry` side emits a span → OTLP → Langfuse
-  ("here is the exact prompt and completion of THAT slow call").
+- `MeterRegistry` 侧发射 histogram → Prometheus → Grafana（“LLM 调用延迟 P99”）；
+- `ObservationRegistry` 侧发射 Span → OTLP → Langfuse（“这次慢请求的具体 Prompt 和 Completion 是什么”）。
 
-Zero double-instrumentation cost.
+零重复埋点成本。
 
-### B.5 Operational division of labor (worked example)
+### B.5 运维分工示例
 
-> User complains: "Today the bot is slow."
+> 用户反映：“今天 Bot 很慢。”
 >
-> 1. Open **Grafana** → spot a P99 spike between 14:30 – 14:45.
-> 2. Note from the same dashboard that token rate is normal but tool-call
->    latency doubled.
-> 3. Switch to **Langfuse** → filter traces in that window, sort by
->    duration → open one trace → see the offending tool span took 8 s,
->    inspect its full input/output to identify the root cause (e.g.
->    upstream API throttling).
+> 1. 打开 **Grafana** → 发现 14:30–14:45 间 P99 有尖刺。
+> 2. 同一看板显示 Token 率正常，但 Tool 调用延迟翻倍。
+> 3. 切换到 **Langfuse** → 过滤该时间窗的 Trace，按时长排序 → 打开一个 Trace → 发现问题 Tool Span 耗时 8 秒，检查其完整 Input/Output 定位根本原因（例如上游 API 限流）。
 
-Grafana cannot show that single prompt; Langfuse cannot show
-fleet-wide trends. Each owns half the picture.
+Grafana 无法展示单次 Prompt 内容；Langfuse 无法展示车队级趋势。各占一半可观测性图景。
 
-### B.6 One-line analogy
+### B.6 一句话类比
 
-- **Prometheus + Grafana** = annual physical exam report (trends, alerts).
-- **Langfuse** = patient chart (full record of each consultation, replayable).
+- **Prometheus + Grafana** = 年度体检报告（趋势、预警）。
+- **Langfuse** = 病历档案（每次问诊的完整记录，可回放）。
 
-Both are necessary; neither replaces the other.
+两者缺一不可，互不替代。

--- a/docs/superpowers/specs/2026-05-11-langfuse-integration-design.md
+++ b/docs/superpowers/specs/2026-05-11-langfuse-integration-design.md
@@ -247,3 +247,139 @@ to drive the **Sessions** view.
 3. Existing users running `docker compose up` get the new stack
    automatically; opt-out is `docker compose up app postgres redis`
    (explicit service list).
+
+---
+
+## Appendix A — How Langfuse Integrates Without an Official Java SDK
+
+dawn-ai never imports a Langfuse client library. The integration is
+**protocol-level, not library-level**:
+
+```
+[1] Spring AI 1.1 auto-instruments ChatModel / Embedding / VectorStore /
+    Advisor / Tool calls via the Micrometer Observation API (built-in,
+    nothing for us to add).
+
+[2] micrometer-tracing-bridge-otel  translates Observation → OpenTelemetry Span.
+
+[3] opentelemetry-exporter-otlp     serializes Spans into OTLP
+    (HTTP + Protobuf, an open industry-standard protocol) and POSTs to
+    http://langfuse-web:3000/api/public/otel/v1/traces
+    Header: Authorization: Basic base64(public_key:secret_key)
+
+[4] Langfuse v3 server implements an OTLP-compatible ingestion endpoint
+    and decodes incoming OTel Spans into its internal
+    Trace / Observation / Generation model, persisted to ClickHouse.
+```
+
+**Why no SDK is needed**: Langfuse exposes itself as a standard OTLP
+trace backend. Any language with an OpenTelemetry exporter can talk to
+it. Analogous to: MySQL has no official Rust driver, but Rust programs
+connect because the MySQL Wire Protocol is public — clients only need
+to speak the protocol.
+
+**Caveat**: span attribute names must follow Langfuse's documented OTel
+semantic conventions (`session.id`, `gen_ai.usage.input_tokens`,
+`gen_ai.prompt`, …) for the UI to interpret them correctly. This is why
+§7.1 explicitly emits `session.id` via an `ObservationFilter` — Spring
+AI does not emit it by default.
+
+> Langfuse also offers a **private** ingestion API (`/api/public/ingestion`,
+> custom JSON) that *does* require an SDK to consume. We deliberately
+> avoid it; OTLP gives us the same coverage with zero proprietary deps.
+
+---
+
+## Appendix B — OTLP / Langfuse vs. Prometheus + Grafana
+
+The two stacks address **different pillars of observability** and stay
+side-by-side, **not as replacements for each other**.
+
+### B.1 Three pillars
+
+| Pillar | Data shape | Question it answers | Owned by |
+|--------|------------|---------------------|----------|
+| **Metrics** | time-series numerics (counter / histogram) | "How fast/stable overall? P99? error rate?" | **Prometheus + Grafana** (existing) |
+| **Traces** | causally-linked span tree + context | "Why was **this one** request slow / wrong / expensive? What prompt? Which tools?" | **OTLP → Langfuse** (new) |
+| Logs | structured text | "What exactly happened at the moment of failure?" | logback (not centralized yet) |
+
+### B.2 Topology after integration
+
+```
+                           dawn-ai (Spring Boot)
+                                   │
+                  ┌────────────────┴────────────────┐
+                  │ Micrometer (unified observation) │
+                  │  - MeterRegistry      (metrics)  │
+                  │  - ObservationRegistry (traces)  │
+                  └──────┬──────────────────┬────────┘
+                         │                  │
+              ┌──────────▼─────┐   ┌────────▼──────────────┐
+              │ Prometheus     │   │ tracing-bridge-otel   │
+              │ Registry       │   │   ↓                   │
+              │ (/actuator/    │   │ OTel SDK              │
+              │  prometheus)   │   │   ↓ OTLP/HTTP (push)  │
+              └────────┬───────┘   │                       │
+                       │ pull       └──────────┬────────────┘
+                       ▼                       ▼
+              ┌────────────────┐      ┌────────────────────┐
+              │ Prometheus TSDB│      │ Langfuse v3        │
+              └────────┬───────┘      │ (OTLP ingest +     │
+                       ▼              │  ClickHouse) + UI  │
+              ┌────────────────┐      └────────────────────┘
+              │ Grafana        │
+              └────────────────┘
+                       ↑                       ↑
+              "Trends, SLOs,             "Per-session deep-dive:
+               aggregated rates"          prompt, tool calls,
+                                          why slow / costly"
+```
+
+### B.3 OTLP vs. Prometheus protocol — clarifying overlap
+
+| Aspect | Prometheus | OTLP |
+|--------|------------|------|
+| Standard owner | Prometheus project (CNCF) | OpenTelemetry (CNCF) |
+| Direction | Server **pulls** `/metrics` from app | App **pushes** to collector / backend |
+| Carries metrics? | Yes (its only purpose) | Yes — but we don't use this leg |
+| Carries traces? | No | **Yes** — what we use |
+| Carries logs? | No | Yes (optional) |
+
+OTLP can theoretically replace Prometheus for metrics too (via OTel
+Collector → `prometheus_remote_write`), but we **deliberately don't**:
+existing metrics pipeline is healthy; refactoring it brings no value
+and risks regression. This integration touches **only the trace leg**.
+
+### B.4 Same instrumentation, two outputs
+
+A single piece of Micrometer instrumentation — e.g. Spring AI's
+`ChatModel` observation — feeds **both** sinks simultaneously:
+
+- the `MeterRegistry` side emits histogram → Prometheus → Grafana
+  ("LLM call latency P99");
+- the `ObservationRegistry` side emits a span → OTLP → Langfuse
+  ("here is the exact prompt and completion of THAT slow call").
+
+Zero double-instrumentation cost.
+
+### B.5 Operational division of labor (worked example)
+
+> User complains: "Today the bot is slow."
+>
+> 1. Open **Grafana** → spot a P99 spike between 14:30 – 14:45.
+> 2. Note from the same dashboard that token rate is normal but tool-call
+>    latency doubled.
+> 3. Switch to **Langfuse** → filter traces in that window, sort by
+>    duration → open one trace → see the offending tool span took 8 s,
+>    inspect its full input/output to identify the root cause (e.g.
+>    upstream API throttling).
+
+Grafana cannot show that single prompt; Langfuse cannot show
+fleet-wide trends. Each owns half the picture.
+
+### B.6 One-line analogy
+
+- **Prometheus + Grafana** = annual physical exam report (trends, alerts).
+- **Langfuse** = patient chart (full record of each consultation, replayable).
+
+Both are necessary; neither replaces the other.

--- a/docs/telemetry/langfuse.md
+++ b/docs/telemetry/langfuse.md
@@ -2,8 +2,3 @@
 
 - [ ] ReAct范式中的tool call with LLM，没有捕捉到
 - [ ] embedding model中的call，output信息确实，现实undefined
-
-
-
-
-

--- a/pom.xml
+++ b/pom.xml
@@ -108,6 +108,12 @@
             <artifactId>opentelemetry-exporter-otlp</artifactId>
         </dependency>
 
+        <!-- OpenTelemetry SDK AutoConfigure SPI (for @Bean customizers) -->
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-sdk-extension-autoconfigure-spi</artifactId>
+        </dependency>
+
         <!-- Lombok -->
         <dependency>
             <groupId>org.projectlombok</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -96,6 +96,18 @@
             <artifactId>micrometer-registry-prometheus</artifactId>
         </dependency>
 
+        <!-- Micrometer Tracing → OpenTelemetry bridge -->
+        <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-tracing-bridge-otel</artifactId>
+        </dependency>
+
+        <!-- OpenTelemetry OTLP exporter (HTTP/Protobuf) -->
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-exporter-otlp</artifactId>
+        </dependency>
+
         <!-- Lombok -->
         <dependency>
             <groupId>org.projectlombok</groupId>

--- a/scripts/langfuse-auth-header.sh
+++ b/scripts/langfuse-auth-header.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# Generate the value of LANGFUSE_AUTH_BASE64 used by the OTLP exporter.
+# Reads LANGFUSE_INIT_PROJECT_PUBLIC_KEY / SECRET_KEY from .env (or env).
+set -euo pipefail
+
+if [[ -f .env ]]; then
+  set -a; source .env; set +a
+fi
+
+: "${LANGFUSE_INIT_PROJECT_PUBLIC_KEY:?missing LANGFUSE_INIT_PROJECT_PUBLIC_KEY}"
+: "${LANGFUSE_INIT_PROJECT_SECRET_KEY:?missing LANGFUSE_INIT_PROJECT_SECRET_KEY}"
+
+printf '%s:%s' \
+  "$LANGFUSE_INIT_PROJECT_PUBLIC_KEY" \
+  "$LANGFUSE_INIT_PROJECT_SECRET_KEY" \
+  | base64

--- a/src/main/java/com/dawn/ai/config/AiConfig.java
+++ b/src/main/java/com/dawn/ai/config/AiConfig.java
@@ -20,7 +20,7 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.client.ClientHttpRequestInterceptor;
 import org.springframework.http.client.BufferingClientHttpRequestFactory;
 import org.springframework.http.client.ClientHttpResponse;
-import org.springframework.http.client.SimpleClientHttpRequestFactory;
+import org.springframework.http.client.JdkClientHttpRequestFactory;
 import org.springframework.http.client.reactive.ClientHttpRequest;
 import org.springframework.http.client.reactive.ClientHttpRequestDecorator;
 import org.springframework.web.reactive.function.BodyInserter;
@@ -94,9 +94,21 @@ public class AiConfig {
             String responseBodyText = new String(responseBody, resolveCharset(response.getHeaders()));
             AiSyncResponseCapture.set(responseBodyText);
 
-            log.info("[AI HTTP] <-- status={} | {}", response.getStatusCode(), summarizeResponseBody(responseBodyText));
-            if (log.isDebugEnabled()) {
-                log.debug("[AI HTTP] <-- response body detail:\n{}", formatDebugResponseBody(responseBodyText));
+            if (response.getStatusCode().isError()) {
+                // Failure path: dump full request + response so the upstream rejection reason is
+                // visible in logs instead of being swallowed inside the IOException wrapper.
+                log.error("[AI HTTP] <-- ERROR status={} latencyMs={} url={} {}\nrequestBody={}\nresponseBody={}",
+                        response.getStatusCode(),
+                        latency,
+                        request.getMethod(),
+                        request.getURI(),
+                        reqBodyText,
+                        responseBodyText);
+            } else {
+                log.info("[AI HTTP] <-- status={} | {}", response.getStatusCode(), summarizeResponseBody(responseBodyText));
+                if (log.isDebugEnabled()) {
+                    log.debug("[AI HTTP] <-- response body detail:\n{}", formatDebugResponseBody(responseBodyText));
+                }
             }
             aiInteractionLogger.logResponse(sessionId, response.getStatusCode().value(), responseBodyText, latency);
 
@@ -104,7 +116,7 @@ public class AiConfig {
         };
 
         return RestClient.builder()
-                .requestFactory(new BufferingClientHttpRequestFactory(new SimpleClientHttpRequestFactory()))
+                .requestFactory(new BufferingClientHttpRequestFactory(new JdkClientHttpRequestFactory()))
                 .requestInterceptor(loggingInterceptor);
     }
 

--- a/src/main/java/com/dawn/ai/config/LangfuseObservationConfig.java
+++ b/src/main/java/com/dawn/ai/config/LangfuseObservationConfig.java
@@ -1,19 +1,32 @@
 package com.dawn.ai.config;
 
 import io.micrometer.common.KeyValue;
+import io.micrometer.common.KeyValues;
 import io.micrometer.observation.ObservationFilter;
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.sdk.autoconfigure.spi.AutoConfigurationCustomizerProvider;
 import io.opentelemetry.sdk.resources.Resource;
+import org.springframework.ai.chat.messages.Message;
+import org.springframework.ai.chat.model.ChatResponse;
+import org.springframework.ai.chat.model.Generation;
+import org.springframework.ai.chat.observation.ChatModelObservationContext;
+import org.springframework.ai.chat.observation.ChatModelObservationConvention;
+import org.springframework.ai.chat.observation.DefaultChatModelObservationConvention;
+import org.springframework.ai.chat.prompt.Prompt;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
+import java.util.stream.Collectors;
+
 /**
  * Wires dawn-ai's existing per-thread sessionId into Spring AI's
  * Micrometer Observations so Langfuse can group traces by chat session,
- * and labels every exported span with a process-wide environment tag.
+ * labels every exported span with a process-wide environment tag, and
+ * surfaces full chat prompt + completion text on each LLM observation
+ * (Spring AI's built-in {@code log-prompt} switch only writes to SLF4J
+ * and never reaches the OTel span).
  */
 @Configuration
 public class LangfuseObservationConfig {
@@ -46,5 +59,44 @@ public class LangfuseObservationConfig {
         return customizer -> customizer.addResourceCustomizer((resource, props) ->
                 resource.merge(Resource.create(Attributes.of(
                         AttributeKey.stringKey("langfuse.environment"), env))));
+    }
+
+    /**
+     * Adds {@code gen_ai.prompt} and {@code gen_ai.completion} as
+     * high-cardinality KeyValues so the OTLP exporter ships full prompt and
+     * completion text. Langfuse v3 reads these GenAI semantic-convention
+     * attributes and renders them as the observation's input/output.
+     */
+    @Bean
+    public ChatModelObservationConvention langfuseChatModelObservationConvention() {
+        return new DefaultChatModelObservationConvention() {
+            @Override
+            public KeyValues getHighCardinalityKeyValues(ChatModelObservationContext ctx) {
+                KeyValues kvs = super.getHighCardinalityKeyValues(ctx);
+                Prompt request = ctx.getRequest();
+                if (request != null && request.getInstructions() != null) {
+                    String prompt = request.getInstructions().stream()
+                            .map(Message::getText)
+                            .filter(s -> s != null && !s.isEmpty())
+                            .collect(Collectors.joining("\n"));
+                    if (!prompt.isEmpty()) {
+                        kvs = kvs.and("gen_ai.prompt", prompt);
+                    }
+                }
+                ChatResponse response = ctx.getResponse();
+                if (response != null && response.getResults() != null) {
+                    String completion = response.getResults().stream()
+                            .map(Generation::getOutput)
+                            .filter(o -> o != null)
+                            .map(o -> o.getText())
+                            .filter(s -> s != null && !s.isEmpty())
+                            .collect(Collectors.joining("\n"));
+                    if (!completion.isEmpty()) {
+                        kvs = kvs.and("gen_ai.completion", completion);
+                    }
+                }
+                return kvs;
+            }
+        };
     }
 }

--- a/src/main/java/com/dawn/ai/config/LangfuseObservationConfig.java
+++ b/src/main/java/com/dawn/ai/config/LangfuseObservationConfig.java
@@ -1,0 +1,50 @@
+package com.dawn.ai.config;
+
+import io.micrometer.common.KeyValue;
+import io.micrometer.observation.ObservationFilter;
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.sdk.autoconfigure.spi.AutoConfigurationCustomizerProvider;
+import io.opentelemetry.sdk.resources.Resource;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Wires dawn-ai's existing per-thread sessionId into Spring AI's
+ * Micrometer Observations so Langfuse can group traces by chat session,
+ * and labels every exported span with a process-wide environment tag.
+ */
+@Configuration
+public class LangfuseObservationConfig {
+
+    /**
+     * Per-span filter: stamps {@code session.id} on every Observation when
+     * a sessionId is present on the current thread (already propagated by
+     * {@link AiInteractionContext} across Reactor / executor handoffs).
+     * {@code session.id} is the documented Langfuse OTel attribute that drives
+     * the Sessions view.
+     */
+    @Bean
+    public ObservationFilter langfuseSessionFilter() {
+        return ctx -> {
+            String sid = AiInteractionContext.getSessionId();
+            if (sid != null && !sid.isBlank()) {
+                ctx.addLowCardinalityKeyValue(KeyValue.of("session.id", sid));
+            }
+            return ctx;
+        };
+    }
+
+    /**
+     * Process-wide OTel resource attribute. Set once at SDK init rather than
+     * per-span so it doesn't bloat every span payload.
+     */
+    @Bean
+    public AutoConfigurationCustomizerProvider langfuseResourceCustomizer(
+            @Value("${langfuse.environment:dev}") String env) {
+        return customizer -> customizer.addResourceCustomizer((resource, props) ->
+                resource.merge(Resource.create(Attributes.of(
+                        AttributeKey.stringKey("langfuse.environment"), env))));
+    }
+}

--- a/src/main/java/com/dawn/ai/config/LangfuseObservationConfig.java
+++ b/src/main/java/com/dawn/ai/config/LangfuseObservationConfig.java
@@ -21,22 +21,35 @@ import org.springframework.context.annotation.Configuration;
 import java.util.stream.Collectors;
 
 /**
- * Wires dawn-ai's existing per-thread sessionId into Spring AI's
- * Micrometer Observations so Langfuse can group traces by chat session,
- * labels every exported span with a process-wide environment tag, and
- * surfaces full chat prompt + completion text on each LLM observation
- * (Spring AI's built-in {@code log-prompt} switch only writes to SLF4J
- * and never reaches the OTel span).
+ * 将 dawn-ai 现有的线程级 sessionId 注入 Spring AI 的 Micrometer Observation 体系，
+ * 使 Langfuse 能够按会话维度聚合 Trace；同时为每个导出 Span 打上进程级环境标签，
+ * 并在每次 LLM Observation 上附加完整的 prompt 和 completion 文本。
+ *
+ * <p>为何需要这个配置类：
+ * <ol>
+ *   <li>Spring AI 内置的 {@code spring.ai.chat.observations.log-prompt=true} 只把
+ *       prompt 写入 SLF4J 日志，不会注入到 OTel Span 的 Attribute 中，Langfuse
+ *       因此看不到 Input/Output 内容，必须通过自定义 Convention 手动补齐。</li>
+ *   <li>Langfuse 的 Sessions 视图依赖 OTel Attribute {@code session.id}，但
+ *       Spring AI 默认不传播任何会话标识，需要通过 ObservationFilter 在每个
+ *       Span 写入时从线程上下文中读取并注入。</li>
+ *   <li>Langfuse 的多环境隔离（dev/staging/prod）依赖 OTel Resource Attribute
+ *       {@code langfuse.environment}，这属于进程级静态元数据，应在 SDK
+ *       初始化阶段一次性写入 Resource，而不是每个 Span 重复携带。</li>
+ * </ol>
  */
 @Configuration
 public class LangfuseObservationConfig {
 
     /**
-     * Per-span filter: stamps {@code session.id} on every Observation when
-     * a sessionId is present on the current thread (already propagated by
-     * {@link AiInteractionContext} across Reactor / executor handoffs).
-     * {@code session.id} is the documented Langfuse OTel attribute that drives
-     * the Sessions view.
+     * 【为何需要此 Bean】
+     * Spring AI 的 Observation 不感知业务层的会话概念，所有 LLM 调用在 Langfuse
+     * 中默认是孤立 Trace，无法按用户会话聚合查看对话历史。
+     *
+     * <p>此过滤器在每个 Span 写出前从当前线程（已由 {@link AiInteractionContext}
+     * 跨 Reactor/线程池边界传播）读取 sessionId，注入为低基数 KeyValue
+     * {@code session.id}。这是 Langfuse OTel 协议中驱动 Sessions 视图的
+     * 官方文档属性，注入后所有属于同一对话的 Trace 会自动归组。
      */
     @Bean
     public ObservationFilter langfuseSessionFilter() {
@@ -50,8 +63,15 @@ public class LangfuseObservationConfig {
     }
 
     /**
-     * Process-wide OTel resource attribute. Set once at SDK init rather than
-     * per-span so it doesn't bloat every span payload.
+     * 【为何需要此 Bean】
+     * Langfuse 支持多环境隔离，通过 OTel Resource Attribute {@code langfuse.environment}
+     * 区分 dev / staging / prod 的数据，避免测试流量污染生产看板。
+     *
+     * <p>Resource Attribute 是进程级静态元数据，在 OTel SDK 初始化时写入一次即可，
+     * 后续所有 Span 导出时都会自动携带，无需在每个 Span 上重复添加（与
+     * Span Attribute 相比可显著减少网络传输和 ClickHouse 存储开销）。
+     * 通过 {@link AutoConfigurationCustomizerProvider} 钩子合并到全局 Resource 中，
+     * 是 OpenTelemetry Java Agent / SDK 的标准扩展点。
      */
     @Bean
     public AutoConfigurationCustomizerProvider langfuseResourceCustomizer(
@@ -62,10 +82,22 @@ public class LangfuseObservationConfig {
     }
 
     /**
-     * Adds {@code gen_ai.prompt} and {@code gen_ai.completion} as
-     * high-cardinality KeyValues so the OTLP exporter ships full prompt and
-     * completion text. Langfuse v3 reads these GenAI semantic-convention
-     * attributes and renders them as the observation's input/output.
+     * 【为何需要重写此 Bean】
+     * Spring AI 默认的 {@link DefaultChatModelObservationConvention} 出于隐私
+     * 和性能考虑，不会将 prompt 文本和 completion 文本写入 OTel Span Attribute，
+     * 导致 Langfuse 的 Trace 详情页只能看到 token 用量和模型名称，看不到
+     * 实际的对话内容，严重影响可观测性和调试效率。
+     *
+     * <p>重写原因分解：
+     * <ul>
+     *   <li>{@code gen_ai.prompt}：GenAI 语义约定标准属性，Langfuse v3 读取此字段
+     *       渲染 Trace 的 Input 面板，不注入则 Input 为空。</li>
+     *   <li>{@code gen_ai.completion}：对应 Trace 的 Output 面板，不注入则
+     *       无法在 Langfuse 中直接查看模型回复内容。</li>
+     *   <li>作为高基数（High Cardinality）KeyValue 注入：prompt/completion 文本
+     *       内容各不相同，属于高基数数据，应使用 {@code getHighCardinalityKeyValues}
+     *       而非低基数接口，符合 Micrometer Observation 的语义分层规范。</li>
+     * </ul>
      */
     @Bean
     public ChatModelObservationConvention langfuseChatModelObservationConvention() {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -55,14 +55,6 @@ spring:
         dimensions: ${EMBEDDING_DIMENSIONS:1024}
         initialize-schema: true
 
-    chat:
-      observations:
-        log-prompt: true
-        log-completion: true
-    tools:
-      observations:
-        include-content: true
-
 server:
   port: 8080
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -55,10 +55,18 @@ spring:
         dimensions: ${EMBEDDING_DIMENSIONS:1024}
         initialize-schema: true
 
+    chat:
+      observations:
+        log-prompt: true
+        log-completion: true
+    tools:
+      observations:
+        include-content: true
+
 server:
   port: 8080
 
-# Actuator & Prometheus Metrics
+# Actuator & Prometheus Metrics + OTLP tracing → Langfuse
 management:
   endpoints:
     web:
@@ -71,6 +79,15 @@ management:
     export:
       prometheus:
         enabled: true
+  tracing:
+    sampling:
+      probability: 1.0
+  otlp:
+    tracing:
+      endpoint: ${LANGFUSE_OTLP_ENDPOINT:http://localhost:3001/api/public/otel/v1/traces}
+      compression: gzip
+      headers:
+        Authorization: Basic ${LANGFUSE_AUTH_BASE64:}
 
 # Application config
 app:
@@ -131,3 +148,7 @@ logging:
     org.springframework.ai: INFO
   pattern:
     console: "%d{yyyy-MM-dd HH:mm:ss} [%thread] %-5level %logger{36}:%line - %msg%n"
+
+# Langfuse environment label, attached as OTel resource attribute
+langfuse:
+  environment: ${LANGFUSE_ENVIRONMENT:dev}

--- a/src/test/java/com/dawn/ai/config/AiConfigErrorLoggingTest.java
+++ b/src/test/java/com/dawn/ai/config/AiConfigErrorLoggingTest.java
@@ -1,0 +1,114 @@
+package com.dawn.ai.config;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import com.sun.net.httpserver.HttpServer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.slf4j.LoggerFactory;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.RestClient;
+
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.contains;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+/**
+ * Regression test for the upstream 4xx visibility fix.
+ *
+ * Prior bug: openAiRestClientBuilder used SimpleClientHttpRequestFactory (JDK
+ * HttpURLConnection). When upstream returned 4xx, getInputStream() threw IOException
+ * and Spring wrapped it as ResourceAccessException — the actual error body from the
+ * provider was never read or logged. This test guards against any regression by
+ * verifying the interceptor:
+ *   1. surfaces a normal HttpClientErrorException carrying the upstream body,
+ *   2. captures the body into AiSyncResponseCapture (used by TaskPlanner fallback),
+ *   3. forwards the body to AiInteractionLogger,
+ *   4. emits the body at ERROR level on the [AI HTTP] logger.
+ */
+class AiConfigErrorLoggingTest {
+
+    private static final String ERROR_BODY =
+            "{\"error\":{\"code\":\"400\",\"message\":\"Param Incorrect\",\"param\":\"Not supported model X\"}}";
+
+    private HttpServer server;
+    private int port;
+    private ListAppender<ILoggingEvent> logAppender;
+    private Logger aiConfigLogger;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+        server.createContext("/v1/chat/completions", exchange -> {
+            byte[] body = ERROR_BODY.getBytes(StandardCharsets.UTF_8);
+            exchange.getResponseHeaders().add("Content-Type", "application/json");
+            exchange.sendResponseHeaders(400, body.length);
+            try (OutputStream os = exchange.getResponseBody()) {
+                os.write(body);
+            }
+        });
+        port = server.getAddress().getPort();
+        server.start();
+
+        aiConfigLogger = (Logger) LoggerFactory.getLogger(AiConfig.class);
+        logAppender = new ListAppender<>();
+        logAppender.start();
+        aiConfigLogger.addAppender(logAppender);
+    }
+
+    @AfterEach
+    void tearDown() {
+        if (server != null) {
+            server.stop(0);
+        }
+        if (logAppender != null) {
+            aiConfigLogger.detachAppender(logAppender);
+        }
+        AiSyncResponseCapture.clear();
+        AiInteractionContext.clear();
+    }
+
+    @Test
+    void interceptor_shouldSurfaceUpstream4xxBody_insteadOfSwallowingIt() {
+        AiInteractionLogger interactionLogger = mock(AiInteractionLogger.class);
+        AiConfig config = new AiConfig();
+        RestClient client = config.openAiRestClientBuilder(interactionLogger)
+                .baseUrl("http://127.0.0.1:" + port)
+                .build();
+
+        assertThatThrownBy(() -> client.post()
+                .uri("/v1/chat/completions")
+                .body("{\"model\":\"X\",\"messages\":[{\"role\":\"user\",\"content\":\"hi\"}]}")
+                .retrieve()
+                .toEntity(String.class))
+                .isInstanceOf(HttpClientErrorException.class)
+                .hasMessageContaining("Not supported model X");
+
+        // Body must be captured for the TaskPlanner reasoning-extraction fallback path.
+        assertThat(AiSyncResponseCapture.get()).contains("Not supported model X");
+
+        // AiInteractionLogger receives the full upstream body, not a placeholder.
+        verify(interactionLogger).logResponse(any(), eq(400), contains("Not supported model X"), anyLong());
+
+        // The upstream body is logged at ERROR level so operators can see it without DEBUG.
+        boolean errorLogged = logAppender.list.stream()
+                .anyMatch(e -> e.getLevel() == Level.ERROR
+                        && e.getFormattedMessage().contains("Not supported model X")
+                        && e.getFormattedMessage().contains("[AI HTTP] <-- ERROR"));
+        assertThat(errorLogged)
+                .as("expected an ERROR log line containing the upstream 4xx body")
+                .isTrue();
+    }
+}

--- a/src/test/java/com/dawn/ai/config/LangfuseObservationConfigTest.java
+++ b/src/test/java/com/dawn/ai/config/LangfuseObservationConfigTest.java
@@ -1,0 +1,61 @@
+package com.dawn.ai.config;
+
+import io.micrometer.common.KeyValue;
+import io.micrometer.observation.Observation;
+import io.micrometer.observation.ObservationFilter;
+import io.micrometer.observation.ObservationRegistry;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class LangfuseObservationConfigTest {
+
+    private final LangfuseObservationConfig config = new LangfuseObservationConfig();
+
+    @AfterEach
+    void clear() {
+        AiInteractionContext.clear();
+    }
+
+    @Test
+    void filterEmitsSessionIdWhenContextHasOne() {
+        AiInteractionContext.setSessionId("sess-123");
+        ObservationFilter filter = config.langfuseSessionFilter();
+
+        Observation.Context ctx = newContext();
+        filter.map(ctx);
+
+        assertThat(ctx.getLowCardinalityKeyValues())
+                .contains(KeyValue.of("session.id", "sess-123"));
+    }
+
+    @Test
+    void filterEmitsNothingWhenContextEmpty() {
+        ObservationFilter filter = config.langfuseSessionFilter();
+
+        Observation.Context ctx = newContext();
+        filter.map(ctx);
+
+        assertThat(ctx.getLowCardinalityKeyValues())
+                .noneMatch(kv -> kv.getKey().equals("session.id"));
+    }
+
+    @Test
+    void filterIgnoresBlankSessionId() {
+        AiInteractionContext.setSessionId("   ");
+        ObservationFilter filter = config.langfuseSessionFilter();
+
+        Observation.Context ctx = newContext();
+        filter.map(ctx);
+
+        assertThat(ctx.getLowCardinalityKeyValues())
+                .noneMatch(kv -> kv.getKey().equals("session.id"));
+    }
+
+    private Observation.Context newContext() {
+        Observation.Context ctx = new Observation.Context();
+        ctx.setName("test.observation");
+        return ctx;
+    }
+}


### PR DESCRIPTION
## 摘要

接入自托管 **Langfuse v3** 做 LLM 可观测，并重新设计 compose 布局与每个容器的内存预算，让全套服务在 24 GB Mac 上跑得舒服。

### 新增能力
- **Langfuse v3 self-hosted 栈** — `langfuse-web` + `langfuse-worker` + `clickhouse` + `minio` + 独立的 `langfuse-postgres` / `langfuse-redis`，由一次性的 `minio-init` 负责创建 bucket。
- **OTLP 链路** — 引入 `micrometer-tracing-bridge-otel` + `opentelemetry-exporter-otlp`；Spring AI 的 chat / embedding / vector-store / tool 全部以 trace 形式上报到 Langfuse，附带完整 prompt / completion / 工具 I/O。
- **会话聚合** — `LangfuseObservationConfig` 注入 `session.id` 作为 `ObservationFilter`，并将 `langfuse.environment` 写入 OTel resource。

### Compose 布局
- 主 `docker-compose.yml` 只保留 **app / postgres / redis**（~1.1 GB）。
- 新增 `docker-compose.observe.yml` overlay，两个独立 profile：
  - `--profile metrics` → Prometheus + Grafana
  - `--profile observe` → Langfuse 全家桶
- overlay 通过 service-merge 在 `app` 容器上自动覆盖 `MANAGEMENT_TRACING_ENABLED=true`，无需手工切换。

### 内存调优
- **JVM**：`MaxRAMPercentage=70 + SerialGC + MaxMetaspaceSize=128m + ReservedCodeCacheSize=64m + ExitOnOOM`，自动跟随 `mem_limit` 伸缩。
- **ClickHouse**：自定义 `clickhouse/config.d/low-memory.xml` 收紧 `max_server_memory_usage`、mark cache、thread pool。
- **Postgres / Redis**（业务侧 + langfuse 侧）：收紧 `shared_buffers` / `maxmemory` / 连接数。
- 所有容器统一加上 `mem_limit` + `mem_reservation`。

### 内存预算

| 模式 | 总占用 |
|---|---:|
| 业务最小 | ~1.1 GB |
| + `--profile metrics` | ~1.6 GB |
| + `--profile observe` | ~3.3 GB |
| 全开 | ~3.7 GB |

### 命名清理
- 废弃项目自定义别名 `LANGFUSE_TRACING_ENABLED`，统一改用 Spring Boot 原生 `MANAGEMENT_TRACING_ENABLED`，少一层翻译。

## 验证清单

- [ ] `docker compose up -d` 仅起 app + postgres + redis
- [ ] `... -f docker-compose.observe.yml --profile metrics up -d` 正常起 Prometheus (9090) + Grafana (3000)
- [ ] `... -f docker-compose.observe.yml --profile observe up -d` 正常起 Langfuse 全家桶；http://localhost:3001 可登录（admin@dawn.local / dawn-admin-123）
- [ ] 调用 `/api/v1/chat` 后数秒内在 Langfuse UI 看到 trace，并按 `sessionId` 聚合
- [ ] `GET /actuator/prometheus` 业务指标完整
- [ ] 全开模式下宿主机 RSS 峰值 < 4 GB
- [ ] 不加 observe overlay 时，在 `.env` 设 `MANAGEMENT_TRACING_ENABLED=false` 可静默 OTLP 警告