### PR TITLE
rag: enable HYDE retrieval

### DIFF
--- a/.claude/hook-log.txt
+++ b/.claude/hook-log.txt
@@ -1,0 +1,1 @@
+2026-05-12T15:21:55Z [cc-design] session-start: fired

--- a/docs/RAG/todo.md
+++ b/docs/RAG/todo.md
@@ -1,0 +1,128 @@
+Reference: 
+
+- https://www.zerozzz.win/posts/knowledge-base-strategies
+
+老大，基于文章内容，整理如下：
+
+---
+
+## ✅ 自研 Agent 集成 RAG — 注意事项 Todolist
+
+### 🏗️ 一、架构设计阶段
+
+- [ ] **禁止"一锅端"**：上线前先对知识资产做分类盘点（结构化/半结构化/非结构化/代码），不同类型规划不同处理管道
+- [ ] **设计路由层**：即使初期只有一个知识库，也要预留路由接口；推荐从 LLM 零样本分类路由起步
+- [ ] **联邦制设计**：将每类知识的 RAG 管道设计为独立可替换的模块，避免耦合
+
+---
+
+### ✂️ 二、切片策略选择
+
+- [ ] **有 Markdown/HTML 标题结构** → `MarkdownHeaderTextSplitter` / `HTMLHeaderTextSplitter`，标题自动入元数据
+- [ ] **普通段落文档（Wiki、博客）** → `RecursiveCharacterTextSplitter`；chunk_size 起点 512~1024 token，overlap 设 10%~20%
+- [ ] **需要深度上下文（法律文书、研究报告）** → `ParentDocumentRetriever`，子块检索 + 父块返回
+- [ ] **非结构化自由文本（客服、评论）** → `SemanticChunker`，保证每块主题纯净
+- [ ] **时序对话/日志** → 任何策略 + 滑动窗口（设置 overlap 或自定义窗口），防止上下文断裂
+- [ ] **代码文件** → 必须使用 AST Splitter（`Language.PYTHON` 等），严禁用普通字符切片
+- [ ] **PDF 中含表格** → 必须用 PyMuPDF / Amazon Textract 布局感知解析，单独提取表格对象
+
+---
+
+### 🏷️ 三、元数据工程
+
+- [ ] **所有文档块必须附加元数据**：来源文件名、页码/章节名、日期/版本、作者/部门
+- [ ] **时序数据追加时间戳**：支持"只查过去N天"等时间过滤
+- [ ] **对话数据追加参与者、会话ID**：支持"只查某用户某产品线"的精确过滤
+- [ ] **法律/财务文档追加合同ID、条款号、签署日期**：支持指哪打哪式查询
+
+---
+
+### 🔍 四、召回策略
+
+- [ ] **有元数据的场景优先做预过滤**，再对子集做语义搜索（不要直接全库大海捞针）
+- [ ] **语义切片块用纯向量相似度搜索**即可，无需额外规则（其纯净度已保证精度）
+- [ ] **Top-K 设置** 要结合 chunk_size 调整，块越小 K 可以适当调大
+- [ ] **代码召回** 要确保向量化时包含函数名、Docstring、代码体三个维度
+
+---
+
+### 🌐 五、跨领域查询（进阶）
+
+- [ ] **评估是否需要 Graph RAG**：若存在"X 与 Y 如何关联"类业务问题，规划知识图谱
+- [ ] **Graph RAG 实施前**：预定义有限的关系类型 Schema（如 `IMPLEMENTS / REPORTED_BY / MENTIONS`），防止LLM生成混乱关系
+- [ ] **做实体归一化**："支付模块"/"Payment Module"/"支付系统"需合并为同一节点
+- [ ] **混合路由**：向量RAG（回答"是什么"）和 Graph RAG（回答"怎么关联"）并存，由 LLM 智能路由
+
+---
+
+### ⚠️ 六、常见坑（避坑清单）
+
+- [ ] 不要把表格压平成纯文本放进向量库（数字失去结构意义）
+- [ ] 不要用同一 chunk_size 处理所有文档（短文档会产生大量无意义小块）
+- [ ] 不要忽略 overlap（边界处的关键信息会被切断导致召回失败）
+- [ ] 不要用字符切片处理代码（函数被拦腰斩断，LLM 必然幻觉）
+- [ ] 不要把对话记录按单轮切分（上下文完全丢失，"金鱼记忆"问题）
+- [ ] LLM 提取图谱三元组**不是100%准确**，上线前需人工抽样校验，上游错误会污染整个图谱
+
+---
+
+### 📈 七、迭代路线
+
+- [ ] **Phase 1**：选一个最高价值场景，端到端跑通 MVP，真实用户反馈驱动调优
+- [ ] **Phase 2**：增加专家小队数量，引入智能路由层，建立统一性能监控
+- [ ] **Phase 3**：启动实体关系提取，接入图数据库，融合混合系统
+
+
+
+# 落地
+## 现状速览（已有 ✓ / 缺口 ✗）
+
+| 维度 | 现状 |
+|---|---|
+| 切片 | ✓ `OverlapTextSplitter`（token+标点边界，全局唯一）  ✗ 无 Markdown/HTML/AST/Semantic |
+| 抽取 | ✓ Tika 处理 PDF/Word/Excel（`BodyContentHandler` 纯文本）  ✗ 表格压平、无页码/章节 |
+| 元数据 | ✓ `source/category/docId/topicId/parentDocumentId/chunkIndex` ✗ 页码、章节、时间戳、作者、版本 |
+| 召回 | ✓ Dense+BM25 混合、RRF、HyDE、QueryRewriter、Reranker、metadata 过滤(eq/in) |
+| 路由 | ✓ `RetrievalRouter`（dense vs hybrid 策略）  ✗ todo 说的"知识域路由"（先分类→走哪条管道） |
+| 父子检索 | ✗ 已存 `parentDocumentId`，但 retrieve 没有 expand 父块 |
+| 评估 | ✓ `RetrievalEvaluator` |
+| Graph RAG | ✗ 完全没有 |
+
+## 可落地点（按 ROI 排序）
+
+**🟢 立刻能做（小改动、不动架构）**
+
+1. **Splitter 按 `DocumentType` 多态分发**
+   `DocumentType` 枚举已存在但所有类型共用一个 Splitter。新增 `MarkdownHeaderSplitter`（标题入元数据）、给 PDF/Word 加章节/页码注入；保留 `OverlapTextSplitter` 作为兜底。→ 对应 todo 一、二的核心。
+
+2. **`DocumentTextExtractor` 改用 XHTML handler + 提取结构化元数据**
+   Tika 已能拿到 `TikaCoreProperties`（页码、标题、作者），现在被 `BodyContentHandler` 丢掉了。换成 `ToXMLContentHandler`/`SAXContentHandler` 解析后：①带页码/章节进元数据；②识别 `<table>` 单独成 chunk 并打 `contentType=table` 标记，至少做到"不混进段落里"。→ 对应 todo 二第 7 条 + 三全部 + 避坑第 1 条。
+
+3. **父子返回（ParentDocumentRetriever 等价实现）**
+   `parentDocumentId` 已写进 metadata，`RagService.retrieve` 加一个可选 expand 步：命中子块后按 `parentDocumentId` 去补回父块或前后兄弟块。配置开关即可。→ 对应 todo 二第 3 条。
+
+4. **`RagRequest` / ingest API 接受额外元数据**
+   开放 `timestamp/author/version/section` 等字段直通 `metadata`；`RetrievalRequest.metadataFilters` 已支持 in/eq 过滤，端到端立即可用。→ todo 三、四第 1 条。
+
+**🟡 值得规划（架构性，先讨论再做）**
+
+5. **知识域路由层**（todo 一第 2 条）
+   当前 `RetrievalRouter` 只决定 dense/hybrid。要做的是再上一层：query→分类(LLM 零样本)→选不同 `RagPipeline`。建议先抽象 `RagPipeline` 接口（ingest + retrieve），让现有 RagService 成为 default pipeline，路由层留 hook，不引入实现。
+
+6. **按 category 差异化 chunk_size / overlap**
+   现在全局 `app.ai.rag.chunk-size=500`，对长法律文档和短客服记录都不合适。改成按 `category`/`DocumentType` 读不同配置。→ 避坑第 2、3、5 条。
+
+**🔴 暂不建议**
+
+7. **AST 代码切片**：取决于知识库是否真有代码资产，目前看不到代码 ingestion 场景，先不投入。
+8. **Graph RAG / 实体抽取**：缺图数据库、缺业务驱动（"X 与 Y 如何关联"类问题），属于 todo 自己的 Phase 3，先不动。
+9. **SemanticChunker**：要二次 embedding 调用，成本高，建议有客服/评论场景后再说。
+
+## 建议的 MVP（一个迭代周期）
+
+打包 **1 + 2 + 4**（Splitter 多态 + Tika 结构化抽取 + 元数据 API 直通）。这三条彼此正交、共享一条 ingest 链路、能立刻验证"元数据驱动过滤"在现有 retrieve 上的效果。**3（父子返回）作为 follow-up**，因为需要顺手做检索侧改动和评估对比。
+
+要不要我针对 MVP 这三条写一份具体的设计 plan？或者你想先讨论哪一条？
+
+---
+小提示：你的提问没有语法问题，"落地的点"用得很自然 👍

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -7,3 +7,10 @@ updated: 2026-05-07 22:46
 4. 引入 Agent 评估系统 #issue26
 5. 支持 Skill 和 MCP 协议 #issue25
 6. 支持更多的 tools 
+
+
+## Issues
+
+```
+[MemoryAccessUpdater] Failed to update lastAccessedAt: PreparedStatementCallback; bad SQL grammar [UPDATE vector_store SET metadata = jsonb_set(metadata, '{lastAccessedAt}', to_jsonb(?::bigint))
+```

--- a/docs/telemetry/langfuse.md
+++ b/docs/telemetry/langfuse.md
@@ -1,0 +1,9 @@
+# todo
+
+- [ ] ReAct范式中的tool call with LLM，没有捕捉到
+- [ ] embedding model中的call，output信息确实，现实undefined
+
+
+
+
+

--- a/src/main/java/com/dawn/ai/agent/tools/KnowledgeSearchTool.java
+++ b/src/main/java/com/dawn/ai/agent/tools/KnowledgeSearchTool.java
@@ -2,6 +2,7 @@ package com.dawn.ai.agent.tools;
 
 import com.dawn.ai.agent.trace.StepCollector;
 import com.dawn.ai.rag.RagService;
+import com.dawn.ai.rag.query.HydeQueryGenerator;
 import com.dawn.ai.rag.query.QueryRewriter;
 import com.dawn.ai.rag.retrieval.RetrievalRequest;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -38,6 +39,7 @@ import java.util.function.Function;
 public class KnowledgeSearchTool implements Function<KnowledgeSearchTool.Request, KnowledgeSearchTool.Response> {
 
     private final QueryRewriter queryRewriter;
+    private final HydeQueryGenerator hydeQueryGenerator;
     private final RagService ragService;
     private final MeterRegistry meterRegistry;
 
@@ -83,7 +85,10 @@ public class KnowledgeSearchTool implements Function<KnowledgeSearchTool.Request
     @Override
     public Response apply(Request req) {
         String rewrittenQuery = queryRewriter.rewrite(req.query());
-        String retrievalKey = buildRetrievalKey(rewrittenQuery, req);
+        // HyDE: turn the (rewritten) keyword query into a hypothetical answer passage.
+        // When disabled, returns input unchanged. Failures fall back to input.
+        String retrievalQuery = hydeQueryGenerator.generate(rewrittenQuery);
+        String retrievalKey = buildRetrievalKey(retrievalQuery, req);
 
         if (StepCollector.isQueryRetrieved(retrievalKey)) {
             dedupCounter.increment();
@@ -94,7 +99,7 @@ public class KnowledgeSearchTool implements Function<KnowledgeSearchTool.Request
 
         Map<String, List<String>> appliedFilters = buildMetadataFilters(req);
         List<Document> docs = ragService.retrieve(RetrievalRequest.builder()
-                .query(rewrittenQuery)
+                .query(retrievalQuery)
                 .topK(defaultTopK)
                 .metadataFilters(appliedFilters)
                 .build());
@@ -104,13 +109,13 @@ public class KnowledgeSearchTool implements Function<KnowledgeSearchTool.Request
         if (docs.isEmpty() && !appliedFilters.isEmpty()) {
             log.warn("[KnowledgeSearchTool] 0 results with filters={}, retrying without metadata filters", appliedFilters);
             docs = ragService.retrieve(RetrievalRequest.builder()
-                    .query(rewrittenQuery)
+                    .query(retrievalQuery)
                     .topK(defaultTopK)
                     .build());
         }
 
-        log.debug("[KnowledgeSearchTool] query='{}' → rewritten='{}', docsFound={}",
-                req.query(), rewrittenQuery, docs.size());
+        log.debug("[KnowledgeSearchTool] query='{}' → rewritten='{}', retrieval='{}', docsFound={}",
+                req.query(), rewrittenQuery, retrievalQuery, docs.size());
 
         return new Response(formatContext(docs), docs.size());
     }

--- a/src/main/java/com/dawn/ai/rag/RagService.java
+++ b/src/main/java/com/dawn/ai/rag/RagService.java
@@ -3,6 +3,7 @@ package com.dawn.ai.rag;
 import com.dawn.ai.config.AiAvailabilityChecker;
 import com.dawn.ai.memory.MemoryAccessUpdater;
 import com.dawn.ai.rag.ingestion.OverlapTextSplitter;
+import com.dawn.ai.rag.query.HydeQueryGenerator;
 import com.dawn.ai.rag.retrieval.fusion.ReciprocalRankFusion;
 import com.dawn.ai.rag.retrieval.RetrievalRequest;
 import com.dawn.ai.rag.retrieval.rerank.RetrievalReranker;
@@ -56,6 +57,7 @@ public class RagService {
     // bind to the retrieval pool rather than relying on type-only resolution.
     private final ExecutorService ragRetrievalExecutor;
     private final MemoryAccessUpdater memoryAccessUpdater;
+    private final HydeQueryGenerator hydeQueryGenerator;
 
     public RagService(VectorStore vectorStore,
                       MeterRegistry meterRegistry,
@@ -66,7 +68,8 @@ public class RagService {
                       RetrievalRouter retrievalRouter,
                       DocumentTransformer splitter,
                       @Qualifier("ragRetrievalExecutor") ExecutorService ragRetrievalExecutor,
-                      MemoryAccessUpdater memoryAccessUpdater) {
+                      MemoryAccessUpdater memoryAccessUpdater,
+                      HydeQueryGenerator hydeQueryGenerator) {
         this.vectorStore = vectorStore;
         this.meterRegistry = meterRegistry;
         this.aiAvailabilityChecker = aiAvailabilityChecker;
@@ -77,6 +80,7 @@ public class RagService {
         this.splitter = splitter;
         this.ragRetrievalExecutor = ragRetrievalExecutor;
         this.memoryAccessUpdater = memoryAccessUpdater;
+        this.hydeQueryGenerator = hydeQueryGenerator;
     }
 
     @Setter
@@ -162,8 +166,12 @@ public class RagService {
         aiAvailabilityChecker.ensureConfigured();
 
         int candidateCount = retrievalRequest.getTopK() * 2;
+
+        // hyde integration
+        String retrievalQuery = hydeQueryGenerator.generate(retrievalRequest.getQuery());
+
         SearchRequest.Builder builder = SearchRequest.builder()
-                .query(retrievalRequest.getQuery())
+                .query(retrievalQuery)
                 .topK(candidateCount)
                 .similarityThreshold(similarityThreshold);
 
@@ -188,7 +196,7 @@ public class RagService {
         List<Document> denseResults = denseFuture.join();
         List<Document> sparseResults = sparseFuture.join();
         log.debug("[RagService] Retrieval candidates: dense={}, sparse={}, strategy={}, query='{}'",
-            denseResults.size(), sparseResults.size(), strategy, retrievalRequest.getQuery());
+            denseResults.size(), sparseResults.size(), strategy, retrievalQuery);
         List<Document> results = shouldUseHybridSearch(strategy)
             ? reciprocalRankFusion.fuse(denseResults, sparseResults)
             : denseResults;
@@ -208,7 +216,7 @@ public class RagService {
         List<Document> limited = reranked.stream().limit(retrievalRequest.getTopK()).toList();
         log.info("[RagService] Retrieved {}/{} docs (strategy={}, threshold={}, filtered={}), query='{}', metadataFilters={}",
                 limited.size(), candidateCount, strategy, similarityThreshold, filteredOut,
-                retrievalRequest.getQuery(), retrievalRequest.getMetadataFilters());
+                retrievalQuery, retrievalRequest.getMetadataFilters());
         // Async: refresh lastAccessedAt for memory docs (type=summary/reflection) that were hit.
         // RAG knowledge docs have no 'type' field and are silently skipped inside the updater.
         memoryAccessUpdater.updateAccessTime(limited);

--- a/src/main/java/com/dawn/ai/rag/query/HydeQueryGenerator.java
+++ b/src/main/java/com/dawn/ai/rag/query/HydeQueryGenerator.java
@@ -1,0 +1,75 @@
+package com.dawn.ai.rag.query;
+
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.ai.chat.client.ChatClient;
+import org.springframework.ai.openai.OpenAiChatOptions;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+/**
+ * HyDE (Hypothetical Document Embeddings) — Gao et al. 2022.
+ *
+ * Generate a single short hypothetical passage that *answers* the user's query,
+ * then use that passage as the retrieval input. The hypothetical text typically
+ * shares vocabulary and embedding-space neighborhood with real relevant docs,
+ * improving recall on zero-shot dense retrieval.
+ *
+ * Pipeline position:
+ *   original query → QueryRewriter (keyword cleanup) → HydeQueryGenerator → retrieve
+ *
+ * Failure behavior: any LLM error → fall back to input query (no exception leaks out).
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class HydeQueryGenerator {
+
+    private static final String SYSTEM_PROMPT = """
+            你是一个领域专家。请基于用户的问题，写一段简短、客观、信息密集的回答（80-150字），
+            就像你正在引用一份真实的参考文档。
+            要求：
+            1. 直接陈述事实，不要使用"我认为"、"可能"等模糊语气。
+            2. 只输出回答正文，不要前缀、不要标题、不要 markdown 格式。
+            3. 即使你不确定答案，也请写出最合理的描述——这段文本仅用于向量检索，不会作为最终答案。
+            """;
+
+    private final ChatClient chatClient;
+
+    @Setter
+    @Value("${app.ai.rag.hyde-enabled:false}")
+    private boolean hydeEnabled;
+
+    /**
+     * Generate hypothetical document for the query. Returns the input query unchanged
+     * when disabled or on any error.
+     */
+    public String generate(String query) {
+        if (!hydeEnabled || query == null || query.isBlank()) {
+            return query;
+        }
+
+        try {
+            String hypothetical = chatClient.prompt()
+                    .system(SYSTEM_PROMPT)
+                    .user(query)
+                    .options(OpenAiChatOptions.builder().temperature(0.3).build())
+                    .call()
+                    .content();
+
+            if (hypothetical == null || hypothetical.isBlank()) {
+                log.warn("[HydeQueryGenerator] LLM returned blank hypothetical doc, falling back to original. query='{}'", query);
+                return query;
+            }
+
+            String trimmed = hypothetical.trim();
+            log.debug("[HydeQueryGenerator] query='{}' → hypothetical='{}'", query, trimmed);
+            return trimmed;
+        } catch (Exception e) {
+            log.warn("[HydeQueryGenerator] Failed to generate hypothetical doc, falling back to original. query='{}', error={}",
+                    query, e.getMessage());
+            return query;
+        }
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -101,6 +101,7 @@ app:
         api-key-prefix: "Bearer "
         max-document-chars: 4000  # 发送到 reranker 的单文档最大字符数
       query-rewrite-enabled: true  # 检索前是否用 LLM 改写查询，false 时原样传入
+      hyde-enabled: true          # 检索前是否用 HyDE 生成假设文档作为查询，默认关闭（每次调用 +1 次 LLM）
       max-calls-per-session: 3    # 每次请求最多 RAG 工具调用次数，独立于 maxSteps
     system-prompt: |
       You are Dawn AI, a helpful and knowledgeable assistant powered by advanced AI.

--- a/src/test/java/com/dawn/ai/agent/tools/KnowledgeSearchToolTest.java
+++ b/src/test/java/com/dawn/ai/agent/tools/KnowledgeSearchToolTest.java
@@ -2,6 +2,7 @@ package com.dawn.ai.agent.tools;
 
 import com.dawn.ai.agent.trace.StepCollector;
 import com.dawn.ai.rag.RagService;
+import com.dawn.ai.rag.query.HydeQueryGenerator;
 import com.dawn.ai.rag.query.QueryRewriter;
 import com.dawn.ai.rag.retrieval.RetrievalRequest;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
@@ -26,6 +27,7 @@ import static org.mockito.Mockito.when;
 class KnowledgeSearchToolTest {
 
     @Mock private QueryRewriter queryRewriter;
+    @Mock private HydeQueryGenerator hydeQueryGenerator;
     @Mock private RagService ragService;
 
     private KnowledgeSearchTool tool;
@@ -34,10 +36,14 @@ class KnowledgeSearchToolTest {
     @BeforeEach
     void setUp() {
         meterRegistry = new SimpleMeterRegistry();
-        tool = new KnowledgeSearchTool(queryRewriter, ragService, meterRegistry);
+        tool = new KnowledgeSearchTool(queryRewriter, hydeQueryGenerator, ragService, meterRegistry);
         tool.setDefaultTopK(5);
         tool.initMetrics();
         StepCollector.init(10);
+        // HyDE is disabled by default; mimic that by making generate() return its input unchanged.
+        org.mockito.Mockito.lenient()
+                .when(hydeQueryGenerator.generate(org.mockito.ArgumentMatchers.anyString()))
+                .thenAnswer(invocation -> invocation.getArgument(0));
     }
 
     @AfterEach

--- a/src/test/java/com/dawn/ai/agent/tools/KnowledgeSearchToolTopicTest.java
+++ b/src/test/java/com/dawn/ai/agent/tools/KnowledgeSearchToolTopicTest.java
@@ -21,17 +21,19 @@ import static org.mockito.Mockito.*;
 class KnowledgeSearchToolTopicTest {
 
     @Mock private com.dawn.ai.rag.query.QueryRewriter queryRewriter;
+    @Mock private com.dawn.ai.rag.query.HydeQueryGenerator hydeQueryGenerator;
     @Mock private RagService ragService;
 
     private KnowledgeSearchTool tool;
 
     @BeforeEach
     void setUp() {
-        tool = new KnowledgeSearchTool(queryRewriter, ragService, new SimpleMeterRegistry());
+        tool = new KnowledgeSearchTool(queryRewriter, hydeQueryGenerator, ragService, new SimpleMeterRegistry());
         tool.setDefaultTopK(5);
         tool.initMetrics();
         StepCollector.init(10);
         when(queryRewriter.rewrite(any())).thenAnswer(inv -> inv.getArgument(0));
+        when(hydeQueryGenerator.generate(any())).thenAnswer(inv -> inv.getArgument(0));
     }
 
     @Test

--- a/src/test/java/com/dawn/ai/rag/RagServiceIngestUuidTest.java
+++ b/src/test/java/com/dawn/ai/rag/RagServiceIngestUuidTest.java
@@ -3,6 +3,7 @@ package com.dawn.ai.rag;
 import com.dawn.ai.config.AiAvailabilityChecker;
 import com.dawn.ai.memory.MemoryAccessUpdater;
 import com.dawn.ai.rag.ingestion.OverlapTextSplitter;
+import com.dawn.ai.rag.query.HydeQueryGenerator;
 import com.dawn.ai.rag.retrieval.RetrievalRouter;
 import com.dawn.ai.rag.retrieval.fusion.ReciprocalRankFusion;
 import com.dawn.ai.rag.retrieval.rerank.HeuristicRetrievalReranker;
@@ -56,7 +57,8 @@ class RagServiceIngestUuidTest {
                 new RetrievalRouter(),
                 new OverlapTextSplitter(4, 2),
                 ragRetrievalExecutor,
-                mock(MemoryAccessUpdater.class));
+                mock(MemoryAccessUpdater.class),
+                mock(HydeQueryGenerator.class));
         ragService.initMetrics();
     }
 

--- a/src/test/java/com/dawn/ai/rag/RagServiceTest.java
+++ b/src/test/java/com/dawn/ai/rag/RagServiceTest.java
@@ -3,6 +3,7 @@ package com.dawn.ai.rag;
 import com.dawn.ai.config.AiAvailabilityChecker;
 import com.dawn.ai.memory.MemoryAccessUpdater;
 import com.dawn.ai.rag.ingestion.OverlapTextSplitter;
+import com.dawn.ai.rag.query.HydeQueryGenerator;
 import com.dawn.ai.rag.retrieval.rerank.CrossEncoderRetrievalReranker;
 import com.dawn.ai.rag.retrieval.rerank.HeuristicRetrievalReranker;
 import com.dawn.ai.rag.retrieval.fusion.ReciprocalRankFusion;
@@ -60,7 +61,8 @@ class RagServiceTest {
                 new RetrievalRouter(),
                 overlapTextSplitter,
                 ragRetrievalExecutor,
-                mock(MemoryAccessUpdater.class));
+                mock(MemoryAccessUpdater.class),
+                mock(HydeQueryGenerator.class));
         // 注入配置值（与 application.yml 一致）
         ragService.setSimilarityThreshold(0.7);
         ragService.setHybridEnabled(false);
@@ -128,7 +130,8 @@ class RagServiceTest {
                 new RetrievalRouter(),
                 new OverlapTextSplitter(4, 2),
                 ragRetrievalExecutor,
-                mock(MemoryAccessUpdater.class));
+                mock(MemoryAccessUpdater.class),
+                mock(HydeQueryGenerator.class));
         localRagService.setSimilarityThreshold(0.7);
         localRagService.setHybridEnabled(false);
         localRagService.initMetrics();

--- a/src/test/java/com/dawn/ai/rag/evaluation/HydeRetrievalEvaluationTest.java
+++ b/src/test/java/com/dawn/ai/rag/evaluation/HydeRetrievalEvaluationTest.java
@@ -1,0 +1,91 @@
+package com.dawn.ai.rag.evaluation;
+
+import com.dawn.ai.rag.query.HydeQueryGenerator;
+import com.dawn.ai.rag.retrieval.RetrievalRequest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.ai.document.Document;
+
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Demonstration test: with the same baseline retrieval engine, the HyDE-rewritten
+ * query string should be a better retrieval input than the bare keyword query
+ * for under-specified / paraphrased queries.
+ *
+ * The retrieval engine here is mocked: real-world hypothetical documents tend to
+ * lexically overlap with relevant chunks, which is exactly what the mock encodes.
+ */
+class HydeRetrievalEvaluationTest {
+
+    private final RetrievalEvaluator evaluator = new RetrievalEvaluator();
+
+    @Test
+    @DisplayName("HyDE 改写后查询 + 同一检索器，metric 应不劣于 baseline")
+    void hyde_improvesRetrievalMetricsOnParaphrasedQueries() {
+        // Same evaluation cases used by RetrievalEvaluatorTest.
+        List<RetrievalEvaluationCase> cases = List.of(
+                new RetrievalEvaluationCase("退款政策怎么走", List.of("doc-2", "doc-3")),
+                new RetrievalEvaluationCase("发票怎么改", List.of("doc-4"))
+        );
+
+        // Baseline retriever: short paraphrased queries miss relevant docs.
+        Map<String, List<Document>> baselineCorpus = Map.of(
+                "退款政策怎么走", List.of(
+                        new Document("doc-1", "pricing overview", Map.of()),
+                        new Document("doc-5", "dashboard summary", Map.of())
+                ),
+                "发票怎么改", List.of(
+                        new Document("doc-5", "dashboard summary", Map.of())
+                )
+        );
+
+        // After HyDE expands to a hypothetical answer, the query string lexically
+        // matches the target docs much better.
+        Map<String, List<Document>> hydeCorpus = Map.of(
+                "退款政策怎么走 → 假设答案：根据退款条款，用户可在 7 天内申请退款...",
+                List.of(
+                        new Document("doc-2", "refund policy details", Map.of()),
+                        new Document("doc-3", "refund invoice steps", Map.of())
+                ),
+                "发票怎么改 → 假设答案：在仪表盘 invoice settings 页面可修改抬头与税号...",
+                List.of(
+                        new Document("doc-4", "invoice settings guide", Map.of()),
+                        new Document("doc-3", "refund invoice steps", Map.of())
+                )
+        );
+
+        // Stubbed HyDE generator that maps query -> hypothetical text used as retrieval key.
+        HydeQueryGenerator hyde = mock(HydeQueryGenerator.class);
+        when(hyde.generate(anyString())).thenAnswer(inv -> {
+            String q = inv.getArgument(0);
+            return switch (q) {
+                case "退款政策怎么走" -> "退款政策怎么走 → 假设答案：根据退款条款，用户可在 7 天内申请退款...";
+                case "发票怎么改" -> "发票怎么改 → 假设答案：在仪表盘 invoice settings 页面可修改抬头与税号...";
+                default -> q;
+            };
+        });
+
+        Function<RetrievalRequest, List<Document>> baselineRetriever =
+                req -> baselineCorpus.getOrDefault(req.getQuery(), List.of());
+
+        Function<RetrievalRequest, List<Document>> hydeRetriever = req -> {
+            String hypothetical = hyde.generate(req.getQuery());
+            return hydeCorpus.getOrDefault(hypothetical, List.of());
+        };
+
+        RetrievalEvaluationReport baseline = evaluator.evaluate(cases, baselineRetriever, 2);
+        RetrievalEvaluationReport withHyde = evaluator.evaluate(cases, hydeRetriever, 2);
+
+        assertThat(withHyde.recallAtK()).isGreaterThan(baseline.recallAtK());
+        assertThat(withHyde.mrrAtK()).isGreaterThan(baseline.mrrAtK());
+        assertThat(withHyde.ndcgAtK()).isGreaterThan(baseline.ndcgAtK());
+    }
+}

--- a/src/test/java/com/dawn/ai/rag/query/HydeQueryGeneratorTest.java
+++ b/src/test/java/com/dawn/ai/rag/query/HydeQueryGeneratorTest.java
@@ -1,0 +1,107 @@
+package com.dawn.ai.rag.query;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.ai.chat.client.ChatClient;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class HydeQueryGeneratorTest {
+
+    @Mock private ChatClient chatClient;
+    @Mock private ChatClient.ChatClientRequestSpec requestSpec;
+    @Mock private ChatClient.CallResponseSpec callResponseSpec;
+
+    private HydeQueryGenerator generator;
+
+    @BeforeEach
+    void setUp() {
+        generator = new HydeQueryGenerator(chatClient);
+    }
+
+    @Test
+    @DisplayName("disabled 时不调用 LLM，原样返回输入")
+    void generate_disabled_returnsOriginalQuery() {
+        generator.setHydeEnabled(false);
+
+        String result = generator.generate("如何配置 Dawn AI 的检索阈值");
+
+        assertThat(result).isEqualTo("如何配置 Dawn AI 的检索阈值");
+        verify(chatClient, never()).prompt();
+    }
+
+    @Test
+    @DisplayName("enabled 时返回 LLM 生成的假设文档（已 trim）")
+    void generate_enabled_returnsHypotheticalDoc() {
+        generator.setHydeEnabled(true);
+        stubChatClient("  Dawn AI 的检索阈值通过 application.yml 中的 app.ai.rag.similarity-threshold 配置，默认 0.6。  ");
+
+        String result = generator.generate("如何配置 Dawn AI 的检索阈值");
+
+        assertThat(result).isEqualTo(
+                "Dawn AI 的检索阈值通过 application.yml 中的 app.ai.rag.similarity-threshold 配置，默认 0.6。");
+        verify(requestSpec).options(any());
+    }
+
+    @Test
+    @DisplayName("传给 LLM user prompt 的应是输入 query")
+    void generate_passesInputQueryToUser() {
+        generator.setHydeEnabled(true);
+        stubChatClient("hypothetical answer");
+
+        generator.generate("某个具体问题");
+
+        verify(requestSpec).user("某个具体问题");
+    }
+
+    @Test
+    @DisplayName("LLM 返回空白时降级为原始查询")
+    void generate_blankResponse_returnsOriginalQuery() {
+        generator.setHydeEnabled(true);
+        stubChatClient("   ");
+
+        String result = generator.generate("query");
+
+        assertThat(result).isEqualTo("query");
+    }
+
+    @Test
+    @DisplayName("LLM 抛异常时降级为原始查询，不向外传播")
+    void generate_llmThrows_returnsOriginalQuery() {
+        generator.setHydeEnabled(true);
+        when(chatClient.prompt()).thenThrow(new RuntimeException("LLM unavailable"));
+
+        String result = generator.generate("query");
+
+        assertThat(result).isEqualTo("query");
+    }
+
+    @Test
+    @DisplayName("空白输入直接返回，不调用 LLM")
+    void generate_blankInput_returnsInputUnchanged() {
+        generator.setHydeEnabled(true);
+
+        assertThat(generator.generate("")).isEqualTo("");
+        assertThat(generator.generate(null)).isNull();
+        verify(chatClient, never()).prompt();
+    }
+
+    private void stubChatClient(String content) {
+        when(chatClient.prompt()).thenReturn(requestSpec);
+        when(requestSpec.system(anyString())).thenReturn(requestSpec);
+        when(requestSpec.user(anyString())).thenReturn(requestSpec);
+        when(requestSpec.options(any())).thenReturn(requestSpec);
+        when(requestSpec.call()).thenReturn(callResponseSpec);
+        when(callResponseSpec.content()).thenReturn(content);
+    }
+}


### PR DESCRIPTION
## Summary
- Add HYDE query generation for RAG retrieval.
- Wire HYDE into RagService and KnowledgeSearchTool behavior.
- Add HYDE-focused unit/evaluation tests and related documentation notes.